### PR TITLE
chore(learner): containerise application

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+.DS_Store
+
+# Ignore docker files.
+.dockerignore
+**/Dockerfile
+**/*.Dockerfile
+
+# Ignore git directory and files.
+.git
+.gitignore
+.gitattributes
+
+# Ignore node modules.
+**/node_modules
+
+# Ignore cache/output directories.
+**/.svelte-kit
+**/build
+**/dist
+**/out
+
+# Ignore environment variables.
+**/*.env*

--- a/apps/learner/Dockerfile
+++ b/apps/learner/Dockerfile
@@ -1,0 +1,75 @@
+# ----------------------------------------
+# Base Stage
+# ----------------------------------------
+FROM node:22.16.0-alpine3.21 AS base
+
+RUN mkdir /app
+WORKDIR /app
+
+# Disable `husky`.
+ENV HUSKY=0
+
+# ----------------------------------------
+# Build Stage
+# ----------------------------------------
+FROM base as build
+
+# Install `pnpm`.
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN mkdir $PNPM_HOME && \
+        wget -qO- "https://github.com/pnpm/pnpm/releases/download/v10.11.0/pnpm-linuxstatic-arm64" > "$PNPM_HOME/pnpm" && \
+        chmod +x $PNPM_HOME/pnpm && \
+        ln -s $PNPM_HOME/pnpm /usr/local/bin/pnpm
+
+# Fetch all the dependencies into the virtual store.
+COPY pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY patches patches
+RUN pnpm fetch
+
+COPY . .
+
+# Install dependencies
+RUN pnpm install --offline
+
+# Build internal dependencies.
+RUN pnpm --filter="@onward/auth" build
+
+# Build learner app.
+RUN pnpm --filter="learner" build
+
+# Install production dependencies.
+RUN find . -type d -name "node_modules" -prune -exec rm -rf {} +
+RUN pnpm install --offline --ignore-scripts --prod
+
+# ----------------------------------------
+# Production Stage
+# ----------------------------------------
+FROM base AS production
+ENV NODE_ENV="production"
+
+RUN apk add --no-cache ca-certificates
+
+# 1. Create a new user named `zero`.
+# 2. Change the permission of `app` folder to user `zero`.
+# 3. Change the current user from `root` to `zero`.
+RUN addgroup -S zero && \
+        adduser -S zero -G zero && \
+        chown zero:zero /app
+
+USER zero
+
+COPY --from=build --chown=zero:zero /app/package.json ./package.json
+COPY --from=build --chown=zero:zero /app/node_modules ./node_modules
+
+COPY --from=build --chown=zero:zero /app/packages/auth/package.json ./packages/auth/package.json
+COPY --from=build --chown=zero:zero /app/packages/auth/node_modules ./packages/auth/node_modules
+COPY --from=build --chown=zero:zero /app/packages/auth/dist ./packages/auth/dist
+
+COPY --from=build --chown=zero:zero /app/apps/learner/package.json ./apps/learner/package.json
+COPY --from=build --chown=zero:zero /app/apps/learner/node_modules ./apps/learner/node_modules
+COPY --from=build --chown=zero:zero /app/apps/learner/build ./apps/learner/build
+
+EXPOSE 3000
+
+CMD ["node", "apps/learner/build/index.js"]

--- a/apps/learner/src/lib/server/valkey.ts
+++ b/apps/learner/src/lib/server/valkey.ts
@@ -19,8 +19,8 @@ export const valkey = await GlideClient.createClient({
   },
   databaseId: Number(url.pathname.slice(1)) || 0,
 
-  // Enable TLS in production.
-  useTLS: env.NODE_ENV === 'production',
+  // Enable TLS if the query string contains `tls=true`.
+  useTLS: url.searchParams.get('tls') === 'true',
 });
 
 // A callback to close the Valkey instance when the server shuts down.

--- a/compose.yml
+++ b/compose.yml
@@ -9,5 +9,14 @@ services:
     volumes:
       - valkey:/data
 
+  learner:
+    image: onward/learner:latest
+    container_name: onward-learner
+    build:
+      context: .
+      dockerfile: apps/learner/Dockerfile
+    ports:
+      - 3000:3000
+
 volumes:
   valkey:


### PR DESCRIPTION
## 🚀 Summary
This PR containerises the learner application so it can be pushed to a container registry once we have a CI/CD pipeline in place.

## ✏️ Changes
- Added `Dockerfile` for learner application.

## 📝 Notes
There is a known [issue](https://github.com/valkey-io/valkey-glide/issues/2812) in ValKey version `1.3.4` that prevents `protobufjs` dependencies from being installed when building the container image. Based on the discussion in the issue thread, a release candidate `1.3.5-rc13` addresses this problem.

As a temporary workaround, we will be using Valkey dependency to `1.3.5-rc13` until a stable `2.0.0` release becomes available. The timeline for the `2.0.0` release is currently unclear, so we'll monitor and update accordingly when it's stable.