### PR TITLE
chore(learner): move build-time `dependencies` as `devDependencies`

### DIFF
--- a/apps/learner/Dockerfile
+++ b/apps/learner/Dockerfile
@@ -6,13 +6,13 @@ FROM node:22.16.0-alpine3.21 AS base
 RUN mkdir /app
 WORKDIR /app
 
-# Disable `husky`.
-ENV HUSKY=0
-
 # ----------------------------------------
 # Build Stage
 # ----------------------------------------
 FROM base as build
+
+# Disable `husky`.
+ENV HUSKY=0
 
 # Install `pnpm`.
 ENV PNPM_HOME="/pnpm"
@@ -40,7 +40,7 @@ RUN pnpm --filter="learner" build
 
 # Install production dependencies.
 RUN find . -type d -name "node_modules" -prune -exec rm -rf {} +
-RUN pnpm install --offline --ignore-scripts --prod
+RUN pnpm --filter="learner" install --offline --ignore-scripts --prod
 
 # ----------------------------------------
 # Production Stage
@@ -61,10 +61,6 @@ USER zero
 
 COPY --from=build --chown=zero:zero /app/package.json ./package.json
 COPY --from=build --chown=zero:zero /app/node_modules ./node_modules
-
-COPY --from=build --chown=zero:zero /app/packages/auth/package.json ./packages/auth/package.json
-COPY --from=build --chown=zero:zero /app/packages/auth/node_modules ./packages/auth/node_modules
-COPY --from=build --chown=zero:zero /app/packages/auth/dist ./packages/auth/dist
 
 COPY --from=build --chown=zero:zero /app/apps/learner/package.json ./apps/learner/package.json
 COPY --from=build --chown=zero:zero /app/apps/learner/node_modules ./apps/learner/node_modules

--- a/apps/learner/package.json
+++ b/apps/learner/package.json
@@ -11,11 +11,11 @@
     "prepare": "svelte-kit sync"
   },
   "dependencies": {
-    "@lucide/svelte": "^0.511.0",
-    "@onward/auth": "workspace:*",
     "@valkey/valkey-glide": "1.3.5-rc13"
   },
   "devDependencies": {
+    "@lucide/svelte": "^0.511.0",
+    "@onward/auth": "workspace:*",
     "@sveltejs/adapter-node": "^5.2.12",
     "@sveltejs/kit": "^2.21.1",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,16 +49,16 @@ importers:
 
   apps/learner:
     dependencies:
+      '@valkey/valkey-glide':
+        specifier: 1.3.5-rc13
+        version: 1.3.5-rc13
+    devDependencies:
       '@lucide/svelte':
         specifier: ^0.511.0
         version: 0.511.0(svelte@5.33.4)
       '@onward/auth':
         specifier: workspace:*
         version: link:../../packages/auth
-      '@valkey/valkey-glide':
-        specifier: 1.3.5-rc13
-        version: 1.3.5-rc13
-    devDependencies:
       '@sveltejs/adapter-node':
         specifier: ^5.2.12
         version: 5.2.12(@sveltejs/kit@2.21.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.33.4)(vite@6.3.5(@types/node@22.15.22)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)))(svelte@5.33.4)(vite@6.3.5(@types/node@22.15.22)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)))


### PR DESCRIPTION
## 🚀 Summary

This PR moves build-time `dependencies` to `devDependencies` to better reflect their usage in the application. This change helps maintain a cleaner separation between runtime and development dependencies, making the application's dependency structure more accurate and maintainable.

## ✏️ Changes

- Moved build-time dependencies from `dependencies` to `devDependencies` in the learner application:
  - `@lucide/svelte`
  - `@onward/auth`