### PR TITLE
ci: require `format`, `lint`, and `check` jobs to pass before `test`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,6 +97,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs: [format, lint, check]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## 🚀 Summary

This PR improves the CI workflow by adding job dependencies to ensure code quality checks are completed before running tests. This change helps catch issues earlier in the CI pipeline and prevents unnecessary test runs when basic code quality checks fail.

## ✏️ Changes

- Modified the `test` job in CI workflow to depend on `format`, `lint`, and `check` jobs