### PR TITLE
chore: prevent `husky` installation in production or CI environments

### DIFF
--- a/.husky/install.js
+++ b/.husky/install.js
@@ -1,0 +1,7 @@
+// Prevent `husky` installation in production or CI environments.
+if (process.env.NODE_ENV === 'production' || process.env.CI === 'true') {
+  process.exit(0);
+}
+
+const husky = (await import('husky')).default;
+console.log(husky());

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,6 +14,15 @@ export default ts.config(
   svelte.configs.recommended,
 
   {
+    files: ['.husky/install.js'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
+
+  {
     files: ['**/*.svelte', '**/*.svelte.js', '**/*.svelte.ts'],
     languageOptions: {
       parserOptions: {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "bootstrap": "pnpm --filter=\"./packages/*\" build",
     "format": "prettier --check \"**/*.{svelte,js,ts,md,html,css,json}\"",
     "lint": "eslint \"**/*.{svelte,js,ts}\"",
-    "prepare": "husky"
+    "prepare": "node .husky/install.js"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",


### PR DESCRIPTION
## 🚀 Summary

This PR adds a configuration to prevent `husky` from being installed in production or CI environments. This is a common best practice to avoid unnecessary dependencies in production builds and CI pipelines, as recommended in the [Husky documentation](https://typicode.github.io/husky/how-to.html#ci-server-and-docker).

## ✏️ Changes

- Added configuration to prevent `husky` installation in production or CI environments
