### PR TITLE
chore(docker): remove `--ignore-scripts` flag when installing production dependencies

### DIFF
--- a/apps/learner/Dockerfile
+++ b/apps/learner/Dockerfile
@@ -6,13 +6,12 @@ FROM node:22.16.0-alpine3.21 AS base
 RUN mkdir /app
 WORKDIR /app
 
+ENV NODE_ENV="production"
+
 # ----------------------------------------
 # Build Stage
 # ----------------------------------------
 FROM base as build
-
-# Disable `husky`.
-ENV HUSKY=0
 
 # Install `pnpm`.
 ENV PNPM_HOME="/pnpm"
@@ -40,13 +39,12 @@ RUN pnpm --filter="learner" build
 
 # Install production dependencies.
 RUN find . -type d -name "node_modules" -prune -exec rm -rf {} +
-RUN pnpm --filter="learner" install --offline --ignore-scripts --prod
+RUN pnpm --filter="learner" install --offline --prod
 
 # ----------------------------------------
 # Production Stage
 # ----------------------------------------
 FROM base AS production
-ENV NODE_ENV="production"
 
 RUN apk add --no-cache ca-certificates
 

--- a/apps/learner/package.json
+++ b/apps/learner/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-check",
-    "prepare": "svelte-kit sync"
+    "prepare": "svelte-kit sync || echo ''"
   },
   "dependencies": {
     "@valkey/valkey-glide": "1.3.5-rc13"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "svelte-package",
     "test": "vitest",
-    "prepare": "svelte-kit sync"
+    "prepare": "svelte-kit sync || echo ''"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
## 🚀 Summary

This PR removes the `--ignore-scripts` flag from the production dependencies installation in Docker. This change ensures that necessary scripts (like `prepare` scripts) are executed during the installation process, which is important for proper dependency setup in the production environment.

## ✏️ Changes

- Removed `--ignore-scripts` flag from production dependencies installation in Docker
- Modified `prepare` script to handle missing `svelte-kit` in production environments, following the pattern from [sveltejs/cli#409](https://github.com/sveltejs/cli/pull/409)

