### PR TITLE
chore(learner): update prisma model

### DIFF
--- a/prisma/migrations/20250606061850_add_name_and_google_provider_id_to_user/migration.sql
+++ b/prisma/migrations/20250606061850_add_name_and_google_provider_id_to_user/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[google_provider_id]` on the table `users` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `google_provider_id` to the `users` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `name` to the `users` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "google_provider_id" TEXT NOT NULL,
+ADD COLUMN     "name" VARCHAR(255) NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_google_provider_id_key" ON "users"("google_provider_id");

--- a/prisma/migrations/20250606064646_create_collections/migration.sql
+++ b/prisma/migrations/20250606064646_create_collections/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "collections" (
+    "id" BIGSERIAL NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "kind" VARCHAR(255) NOT NULL,
+    "title" TEXT NOT NULL,
+    "user_id" BIGINT NOT NULL,
+
+    CONSTRAINT "collections_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "collections" ADD CONSTRAINT "collections_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20250606070036_create_notes/migration.sql
+++ b/prisma/migrations/20250606070036_create_notes/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "notes" (
+    "id" BIGSERIAL NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "content" TEXT NOT NULL,
+    "topic" VARCHAR(255) NOT NULL,
+    "user_id" BIGINT NOT NULL,
+
+    CONSTRAINT "notes_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "notes" ADD CONSTRAINT "notes_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20250606092817_create_multi_learning_units/migration.sql
+++ b/prisma/migrations/20250606092817_create_multi_learning_units/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "multi_learning_units" (
+    "id" BIGSERIAL NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "title" TEXT NOT NULL,
+    "collection" VARCHAR(255) NOT NULL,
+    "tags" VARCHAR(255)[] DEFAULT ARRAY[]::VARCHAR(255)[],
+    "content_type" VARCHAR(255) NOT NULL,
+    "content_url" TEXT NOT NULL,
+
+    CONSTRAINT "multi_learning_units_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/migrations/20250607111459_create_learning_journeys/migration.sql
+++ b/prisma/migrations/20250607111459_create_learning_journeys/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "learning_journeys" (
+    "id" BIGSERIAL NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "is_completed" BOOLEAN NOT NULL DEFAULT false,
+    "last_checkpoint" DECIMAL(65,30) NOT NULL,
+    "user_id" BIGINT NOT NULL,
+    "multi_learning_units_id" BIGINT NOT NULL,
+    "collection_id" BIGINT NOT NULL,
+
+    CONSTRAINT "learning_journeys_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "learning_journeys" ADD CONSTRAINT "learning_journeys_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "learning_journeys" ADD CONSTRAINT "learning_journeys_multi_learning_units_id_fkey" FOREIGN KEY ("multi_learning_units_id") REFERENCES "multi_learning_units"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "learning_journeys" ADD CONSTRAINT "learning_journeys_collection_id_fkey" FOREIGN KEY ("collection_id") REFERENCES "collections"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20250607112649_create_threads/migration.sql
+++ b/prisma/migrations/20250607112649_create_threads/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "threads" (
+    "id" BIGSERIAL NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "is_active" BOOLEAN NOT NULL DEFAULT false,
+    "learning_journeys_id" BIGINT,
+    "collections_id" BIGINT,
+
+    CONSTRAINT "threads_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "threads" ADD CONSTRAINT "threads_learning_journeys_id_fkey" FOREIGN KEY ("learning_journeys_id") REFERENCES "learning_journeys"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "threads" ADD CONSTRAINT "threads_collections_id_fkey" FOREIGN KEY ("collections_id") REFERENCES "collections"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20250607113104_create_messages/migration.sql
+++ b/prisma/migrations/20250607113104_create_messages/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "messages" (
+    "id" BIGSERIAL NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "content" TEXT NOT NULL,
+    "thread_id" BIGINT NOT NULL,
+
+    CONSTRAINT "messages_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "messages" ADD CONSTRAINT "messages_thread_id_fkey" FOREIGN KEY ("thread_id") REFERENCES "threads"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20250607113949_add_cascade_delete_to_learning_journey/migration.sql
+++ b/prisma/migrations/20250607113949_add_cascade_delete_to_learning_journey/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - Added the required column `role` to the `messages` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "learning_journeys" DROP CONSTRAINT "learning_journeys_user_id_fkey";
+
+-- AlterTable
+ALTER TABLE "messages" ADD COLUMN     "role" VARCHAR(255) NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "learning_journeys" ADD CONSTRAINT "learning_journeys_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,9 +10,125 @@ datasource db {
 
 model User {
   id        BigInt   @id @default(autoincrement()) @map("id")
-  email     String   @unique @map("email")
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
+  // Domain-Specific Fields
+  name             String @map("name") @db.VarChar(255)
+  email            String @unique @map("email")
+  googleProviderId String @unique @map("google_provider_id")
+
+  // Relations
+  Collection      Collection[]
+  Note            Note[]
+  LearningJourney LearningJourney[]
+
   @@map("users")
+}
+
+model Collection {
+  id        BigInt   @id @default(autoincrement()) @map("id")
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  // Domain-Specific Fields
+  kind  String @map("kind") @db.VarChar(255)
+  title String @map("title")
+
+  // Relations
+  userId          BigInt            @map("user_id")
+  user            User              @relation(fields: [userId], references: [id], onDelete: Cascade)
+  LearningJourney LearningJourney[]
+  Thread          Thread[]
+
+  @@map("collections")
+}
+
+model Note {
+  id        BigInt   @id @default(autoincrement()) @map("id")
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  // Domain-Specific Fields
+  content String @map("content")
+  topic   String @map("topic") @db.VarChar(255)
+
+  // Relations
+  userId BigInt @map("user_id")
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("notes")
+}
+
+model MultiLearningUnit {
+  id        BigInt   @id @default(autoincrement()) @map("id")
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  // Domain-Specific Fields
+  title           String            @map("title")
+  collection      String            @map("collection") @db.VarChar(255)
+  tags            String[]          @default([]) @map("tags") @db.VarChar(255)
+  content_type    String            @map("content_type") @db.VarChar(255)
+  content_url     String            @map("content_url")
+  LearningJourney LearningJourney[]
+
+  @@map("multi_learning_units")
+}
+
+model LearningJourney {
+  id        BigInt   @id @default(autoincrement()) @map("id")
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  // Domain-Specific Fields
+  is_completed    Boolean @default(false) @map("is_completed")
+  last_checkpoint Decimal @map("last_checkpoint")
+
+  // Relations
+  userId              BigInt @map("user_id")
+  multiLearningUnitId BigInt @map("multi_learning_units_id")
+  collectionId        BigInt @map("collection_id")
+
+  user              User              @relation(fields: [userId], references: [id], onDelete: Cascade)
+  multiLearningUnit MultiLearningUnit @relation(fields: [multiLearningUnitId], references: [id])
+  collection        Collection        @relation(fields: [collectionId], references: [id])
+  Thread            Thread[]
+
+  @@map("learning_journeys")
+}
+
+model Thread {
+  id        BigInt   @id @default(autoincrement()) @map("id")
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  // Domain-Specific Fields
+  isActive Boolean @default(false) @map("is_active")
+
+  // Relations
+  learningJourneyId BigInt? @map("learning_journeys_id")
+  collectionId      BigInt? @map("collections_id")
+
+  learningJourney LearningJourney? @relation(fields: [learningJourneyId], references: [id])
+  collection      Collection?      @relation(fields: [collectionId], references: [id])
+  Message         Message[]
+
+  @@map("threads")
+}
+
+model Message {
+  id        BigInt   @id @default(autoincrement()) @map("id")
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  // Domain-Specific Fields
+  content String @map("content")
+  role    String @map("role") @db.VarChar(255)
+
+  // Relations
+  threadId BigInt @map("thread_id")
+  thread   Thread @relation(fields: [threadId], references: [id])
+
+  @@map("messages")
 }


### PR DESCRIPTION
## 🚀 Summary

This commit introduces the creation of several models and tables in the database schema, along with an update to enable cascade delete behavior for various relationships. These changes set the foundation for managing users, collections, notes, threads, messages, and learning journeys in the system.

## ✏️ Changes

- Added `name` and `google_provider_id` fields to the `User` model
- Created the following tables:
  - `collections`
  - `notes`
  - `multi_learning_units`
  - `learning_journeys`
  - `threads`
  - `messages`
- Enabled `ON DELETE CASCADE` behavior for specific relationships to ensure dependent records are automatically removed when their parent is deleted
- Updated `schema.prisma` to reflect all new models and relationships
- Generated corresponding migrations for the above changes

## 📝 Notes

- **Dependencies**:
  - Ensure the database is migrated to the latest schema using `prisma migrate dev`.
- **Future Improvements**:
  - Add more robust validations or constraints where necessary (e.g., unique constraints on certain fields).