### PR TITLE
chore(learner): create Multi Learning Units table

### DIFF
--- a/prisma/migrations/20250609074602_create_multi_learning_units_table/migration.sql
+++ b/prisma/migrations/20250609074602_create_multi_learning_units_table/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "multi_learning_units" (
+    "id" BIGSERIAL NOT NULL,
+    "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3) NOT NULL,
+    "title" TEXT NOT NULL,
+    "collection" VARCHAR(255) NOT NULL,
+    "tags" VARCHAR(255)[] DEFAULT ARRAY[]::VARCHAR(255)[],
+    "content_type" VARCHAR(255) NOT NULL,
+    "content_url" TEXT NOT NULL,
+
+    CONSTRAINT "multi_learning_units_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,3 +40,18 @@ model Collection {
 
   @@map("collections")
 }
+
+model MultiLearningUnit {
+  id        BigInt   @id @default(autoincrement()) @map("id")
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  // Domain-Specific Fields
+  title        String   @map("title")
+  collection   String   @map("collection") @db.VarChar(255)
+  tags         String[] @default([]) @map("tags") @db.VarChar(255)
+  content_type String   @map("content_type") @db.VarChar(255)
+  content_url  String   @map("content_url")
+
+  @@map("multi_learning_units")
+}


### PR DESCRIPTION
## 🚀 Summary

This PR introduces the database schema changes to support **multiple learning units** functionality. This change lays the foundation for organizing educational content into multiple units within a course structure.

## ✏️ Changes

- Created a new multi_learning_units table in the database schema
- Added necessary table structure and relationships for learning units