### PR TITLE
chore(learner): create Learning Journeys table

### DIFF
--- a/prisma/migrations/20250609082221_create_learning_journeys_table/migration.sql
+++ b/prisma/migrations/20250609082221_create_learning_journeys_table/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "learning_journeys" (
+    "id" BIGSERIAL NOT NULL,
+    "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3) NOT NULL,
+    "is_completed" BOOLEAN NOT NULL DEFAULT false,
+    "last_checkpoint" DECIMAL(65,30) NOT NULL,
+    "user_id" BIGINT NOT NULL,
+    "multi_learning_units_id" BIGINT NOT NULL,
+    "collection_id" BIGINT NOT NULL,
+
+    CONSTRAINT "learning_journeys_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "learning_journeys" ADD CONSTRAINT "learning_journeys_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "learning_journeys" ADD CONSTRAINT "learning_journeys_multi_learning_units_id_fkey" FOREIGN KEY ("multi_learning_units_id") REFERENCES "multi_learning_units"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "learning_journeys" ADD CONSTRAINT "learning_journeys_collection_id_fkey" FOREIGN KEY ("collection_id") REFERENCES "collections"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,7 +19,8 @@ model User {
   googleProviderId String @unique @map("google_provider_id")
 
   // Relations.
-  collections Collection[]
+  collections      Collection[]
+  learningJourneys LearningJourney[]
 
   @@map("users")
 }
@@ -38,6 +39,8 @@ model Collection {
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
+  learningJourneys LearningJourney[]
+
   @@map("collections")
 }
 
@@ -46,12 +49,36 @@ model MultiLearningUnit {
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
 
-  // Domain-Specific Fields
+  // Domain-Specific Fields.
   title        String   @map("title")
   collection   String   @map("collection") @db.VarChar(255)
   tags         String[] @default([]) @map("tags") @db.VarChar(255)
   content_type String   @map("content_type") @db.VarChar(255)
   content_url  String   @map("content_url")
 
+  // Relations.
+  learningJourneys LearningJourney[]
+
   @@map("multi_learning_units")
+}
+
+model LearningJourney {
+  id        BigInt   @id @default(autoincrement()) @map("id")
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  // Domain-Specific Fields.
+  is_completed    Boolean @default(false) @map("is_completed")
+  last_checkpoint Decimal @map("last_checkpoint")
+
+  // Relations.
+  userId              BigInt @map("user_id")
+  multiLearningUnitId BigInt @map("multi_learning_units_id")
+  collectionId        BigInt @map("collection_id")
+
+  user              User              @relation(fields: [userId], references: [id], onDelete: Cascade)
+  multiLearningUnit MultiLearningUnit @relation(fields: [multiLearningUnitId], references: [id])
+  collection        Collection        @relation(fields: [collectionId], references: [id])
+
+  @@map("learning_journeys")
 }


### PR DESCRIPTION
## 🚀 Summary

This PR introduces the database schema changes to support `learning journeys` functionality. This change establishes the foundation for tracking and managing learning paths and progress for users.

## ✏️ Changes

- Created a new `learning_journeys` table in the database schema
- Added necessary table structure and relationships for learning journeys
- Implemented database constraints and indexes for optimal performance