### PR TITLE
chore(learner): create Messages table

### DIFF
--- a/prisma/migrations/20250609085731_create_messages_table/migration.sql
+++ b/prisma/migrations/20250609085731_create_messages_table/migration.sql
@@ -1,0 +1,17 @@
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('USER', 'ASSISTANT');
+
+-- CreateTable
+CREATE TABLE "messages" (
+    "id" BIGSERIAL NOT NULL,
+    "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3) NOT NULL,
+    "content" TEXT NOT NULL,
+    "role" "Role" NOT NULL,
+    "thread_id" BIGINT NOT NULL,
+
+    CONSTRAINT "messages_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "messages" ADD CONSTRAINT "messages_thread_id_fkey" FOREIGN KEY ("thread_id") REFERENCES "threads"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -91,15 +91,39 @@ model Thread {
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
 
-  // Domain-Specific Fields
+  // Domain-Specific Fields.
   isActive Boolean @default(false) @map("is_active")
 
-  // Relations
+  // Relations.
   learningJourneyId BigInt? @map("learning_journeys_id")
   collectionId      BigInt? @map("collections_id")
 
   learningJourney LearningJourney? @relation(fields: [learningJourneyId], references: [id])
   collection      Collection?      @relation(fields: [collectionId], references: [id])
 
+  messages Message[]
+
   @@map("threads")
+}
+
+model Message {
+  id        BigInt   @id @default(autoincrement()) @map("id")
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  // Domain-Specific Fields.
+  content String @map("content")
+  role    Role   @map("role")
+
+  // Relations.
+  threadId BigInt @map("thread_id")
+
+  thread Thread @relation(fields: [threadId], references: [id])
+
+  @@map("messages")
+}
+
+enum Role {
+  USER
+  ASSISTANT
 }


### PR DESCRIPTION
## 🚀 Summary

This PR introduces the database schema changes to support **message** functionality within threads in the learner module. This change establishes the foundation for enabling user-assistant interactions and message history tracking within discussion threads.

## ✏️ Changes

- Created a new messages table in the database schema
- Implemented Message model with the following fields:
  - id: Auto-incrementing primary key
  - createdAt: Timestamp for message creation
  - updatedAt: Timestamp for message updates
  - content: Message content field
  - role: Enum field to distinguish between USER and ASSISTANT messages
- Added relationship between Message and Thread models
- Created Role enum to support message role differentiation

