### PR TITLE
chore: update git hook `pre-push` to only run `check` on affected packages

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,10 @@
-pnpm -r check
+affected_packages=$(pnpm ls --filter '...[origin/main]' --depth=-1 --json | jq -r '.[].name' | grep -v "^onward$" || true)
+if [ -z "$affected_packages" ]; then
+  echo "No affected packages to check."
+  exit 0
+fi
+
+for pkg in $affected_packages; do
+  echo "Running 'pnpm --filter=$pkg check'"
+  pnpm --filter="$pkg" check || exit 1
+done


### PR DESCRIPTION
## 🚀 Summary

This PR updates the git hook `pre-push` to only run `pnpm check` on affected packages.  
This improves the efficiency of the `pre-push` hook by avoiding unnecessary checks on unchanged packages.

## ✏️ Changes

- Updated the `pre-push` git hook to filter and run `pnpm check` only on packages that have changed since `origin/main`
