### PR TITLE
feat(learner): add collection card component

### DIFF
--- a/apps/learner/src/lib/components/Collection.svelte
+++ b/apps/learner/src/lib/components/Collection.svelte
@@ -9,24 +9,24 @@
      */
     title: string;
     /**
-     * The icon component representing the collection.
+     * The icon component representing the Collection.
      */
     icon: typeof Icon;
     /**
-     * Total number of podcasts in this collection.
+     * Total number of podcasts in this Collection.
      */
-    noOfPodcasts: number;
+    numberofpodcasts: number;
     /**
-     * Total number of notes in this collection.
+     * Total number of notes in this Collection.
      */
-    noOfNotes: number;
+    numberofnotes: number;
     /**
-     * Visual colour theme for the card.
+     * Visual colour theme for the Collection.
      */
     variant: Variant;
   }
 
-  let { title, icon: IconComponent, noOfPodcasts, noOfNotes, variant }: Props = $props();
+  let { title, icon: IconComponent, numberofpodcasts, numberofnotes, variant }: Props = $props();
 </script>
 
 <div
@@ -53,7 +53,7 @@
   <span class="text-xl font-semibold text-white">{title}</span>
 
   <div class="flex flex-col">
-    <span class="text-sm text-white">{noOfPodcasts} podcasts</span>
-    <span class="text-sm text-white">{noOfNotes} notes</span>
+    <span class="text-sm text-white">{numberofpodcasts} podcasts</span>
+    <span class="text-sm text-white">{numberofnotes} notes</span>
   </div>
 </div>

--- a/apps/learner/src/routes/(app)/learning/+page.svelte
+++ b/apps/learner/src/routes/(app)/learning/+page.svelte
@@ -9,8 +9,8 @@
   <Collection
     title="Special Educational Needs"
     icon={HandHeart}
-    noOfPodcasts={12}
-    noOfNotes={2}
+    numberofpodcasts={12}
+    numberofnotes={2}
     variant="purple"
   />
 
@@ -18,8 +18,8 @@
   <Collection
     title="Character and Citizenship Education"
     icon={PersonStanding}
-    noOfPodcasts={8}
-    noOfNotes={3}
+    numberofpodcasts={8}
+    numberofnotes={3}
     variant="rose"
   />
 
@@ -27,8 +27,8 @@
   <Collection
     title="Inclusive Education"
     icon={MessageCircleQuestion}
-    noOfPodcasts={10}
-    noOfNotes={1}
+    numberofpodcasts={10}
+    numberofnotes={1}
     variant="amber"
   />
 </div>


### PR DESCRIPTION
## 🚀 Summary

Introduces a reusable `Collection.svelte` card component and updates the Learning page to render a list of collections with consistent colour variants and responsive layout.

## ✏️ Changes

- **feat(components):** added `Collection.svelte`  
  - Accepts `title`, `icon`, `noOfPodcasts`, `noOfNotes`, and `variant` props  
  - Includes Tailwind styling, equal-height support (`h-full` + `auto-rows-fr`)  

- **feat(learning-page):** updated `+page.svelte`  
  - Declared `variantMap` to map collection titles to colour variants  
  - Defined `collections` array and renders it with a single `{#each}` loop  
  - First card spans full width; remaining cards display two-per-row  
  - Passes `variant` to each `Collection` instance

- Removed internal mapping from the component; all colour logic now resides in the page

## 📝 Notes

- If future pages need the same variant logic, consider extracting `variantMap` and the `Variant` type to a shared `lib/types.ts`.  
