### PR TITLE
chore(deps): bump `@valkey/valkey-glide` from `2.0.0` to `2.0.1`

### DIFF
--- a/apps/learner/package.json
+++ b/apps/learner/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@prisma/client": "^6.8.2",
-    "@valkey/valkey-glide": "2.0.0"
+    "@valkey/valkey-glide": "2.0.1"
   },
   "devDependencies": {
     "@lucide/svelte": "^0.511.0",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -22,7 +22,7 @@
     "@sveltejs/kit": "^2.21.1",
     "@sveltejs/package": "^2.3.11",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
-    "@valkey/valkey-glide": "2.0.0",
+    "@valkey/valkey-glide": "2.0.1",
     "svelte": "^5.33.4",
     "typescript": "^5.8.3",
     "vite": "^6.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,8 +86,8 @@ importers:
         specifier: ^6.8.2
         version: 6.8.2(prisma@6.8.2(typescript@5.8.3))(typescript@5.8.3)
       '@valkey/valkey-glide':
-        specifier: 2.0.0
-        version: 2.0.0
+        specifier: 2.0.1
+        version: 2.0.1
     devDependencies:
       '@lucide/svelte':
         specifier: ^0.511.0
@@ -142,8 +142,8 @@ importers:
         specifier: ^5.0.3
         version: 5.0.3(svelte@5.33.4)(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
       '@valkey/valkey-glide':
-        specifier: 2.0.0
-        version: 2.0.0
+        specifier: 2.0.1
+        version: 2.0.1
       svelte:
         specifier: ^5.33.4
         version: 5.33.4
@@ -812,38 +812,38 @@ packages:
     resolution: {integrity: sha512-7RW7CMYoskiz5OOGAWjJFxgb7c5UNjTG292gYhWeOAcFmYCtVCSqjqSBj5zMhxbXo2JOW95YYrUWJfU0zrpaGQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@valkey/valkey-glide-darwin-arm64@2.0.0':
-    resolution: {integrity: sha512-kiVne6nFqB/NetXarsmuuYyVB0fRf7fxfrLHW/cTh5u2eNCiti1BQqdIBPAW0q0PHsDIOvTB64dEjZnWQ8DjUQ==}
+  '@valkey/valkey-glide-darwin-arm64@2.0.1':
+    resolution: {integrity: sha512-IN6hh+2ZKEeYDmiVtNjNRWk3fwFV7nW2CXQBZfxbOakTITRcd7huYSYWTkUAFhu+1nVTQez7VnLArU+BSKFokw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@valkey/valkey-glide-darwin-x64@2.0.0':
-    resolution: {integrity: sha512-8ubNHqBLNgeQviVgZp+W8kFe5V6FSci5Gia9/+djPTb3zXgpAailo9myJqmh2RL6pX3B0M5xtw+6F9WhnOo7Ww==}
+  '@valkey/valkey-glide-darwin-x64@2.0.1':
+    resolution: {integrity: sha512-9dBsnhD3ZZ9dFJwrPYmRWv01mzGygkMpGyvIHSPRPmcDc5G0hZkO/rbP6mYwM5GgA/MT9kLOmUiN1MR5jch5fA==}
     cpu: [x64]
     os: [darwin]
 
-  '@valkey/valkey-glide-linux-arm64-gnu@2.0.0':
-    resolution: {integrity: sha512-ikqvMeqLoEN7JAYTcD2/m7NRFWgEmIhKQgm2PWiu3yprBQnqc083UCrZfgMk/Ey1duhewC7UwKE33aIPKk4XTA==}
+  '@valkey/valkey-glide-linux-arm64-gnu@2.0.1':
+    resolution: {integrity: sha512-/WstihgF2d2frBmcWOP9v5DlRfco5uzhXAdba+mB5x25kd575Yy/3k+ygKqA2e/rfF0KQz1e1SQ679CqpK6lVQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@valkey/valkey-glide-linux-arm64-musl@2.0.0':
-    resolution: {integrity: sha512-gltqidXIDL1m3ucABYX7p80te9GGglqYjeixSRUTLmrUtoA6GnPg3fWF4GybH9Q3tjxz8B/m38mz+VJJZ7fIWA==}
+  '@valkey/valkey-glide-linux-arm64-musl@2.0.1':
+    resolution: {integrity: sha512-pccPAMH4Q7ev0zd/BJBBYQTXOa3MSPYxLzjXAefOJ3OdtyMqYpA7MZ2LgpolJ5TqLAXknkRvSIqNpr28EWBa+g==}
     cpu: [arm64]
     os: [linux]
 
-  '@valkey/valkey-glide-linux-x64-gnu@2.0.0':
-    resolution: {integrity: sha512-WwPLuj/WCCbnQEIbCaugyPK8uDte1YatZhT8Lc8RCPM2UfcKdnKlS8g/2oytojiH5kkAupxUqFsP//9os3DYQg==}
+  '@valkey/valkey-glide-linux-x64-gnu@2.0.1':
+    resolution: {integrity: sha512-wEaxa2oGFxYcNzWl9xEHbTQ/Rng4Q2T93UensUyxY5I6qzBi5ZWrFVIxneyu0uM/bG98SduWBcCyMa9wOcrAQg==}
     cpu: [x64]
     os: [linux]
 
-  '@valkey/valkey-glide-linux-x64-musl@2.0.0':
-    resolution: {integrity: sha512-hFn8zOicEn2D16LaO5pw9QUzOPi67Jj4hJwC/rUUmtmpRnbLN2hqWfxK00/+1k5MBJ8K1764ObvXm4wIY3kehQ==}
+  '@valkey/valkey-glide-linux-x64-musl@2.0.1':
+    resolution: {integrity: sha512-S9WUSDZ8mCH3ZIRvpiJhkknjUOalmH13PqetzMigvUhVoLT3+WBHK3kUvQU78Q1fE1ogoPDdx1Pwp4PAg2bcaQ==}
     cpu: [x64]
     os: [linux]
 
-  '@valkey/valkey-glide@2.0.0':
-    resolution: {integrity: sha512-nJCeRCXgqb7fMEu2dmrdbqOAr/OVpkx2u3dfr+eJuv0zSb/vcanaIH1VZUJAEFMHfvP7WSUfsI6rxZVjJ+/xxQ==}
+  '@valkey/valkey-glide@2.0.1':
+    resolution: {integrity: sha512-qJwyjgNnwGYObYLkFmsM1MvWmiCvYUqBvhe8YzM7bBd22o1CqO0IWnd2INVdCHLA4mQtRbL2JWRWaRKfxVWtTA==}
     engines: {node: '>=16'}
 
   '@vitest/expect@3.1.4':
@@ -2555,35 +2555,35 @@ snapshots:
       '@typescript-eslint/types': 8.33.0
       eslint-visitor-keys: 4.2.0
 
-  '@valkey/valkey-glide-darwin-arm64@2.0.0':
+  '@valkey/valkey-glide-darwin-arm64@2.0.1':
     optional: true
 
-  '@valkey/valkey-glide-darwin-x64@2.0.0':
+  '@valkey/valkey-glide-darwin-x64@2.0.1':
     optional: true
 
-  '@valkey/valkey-glide-linux-arm64-gnu@2.0.0':
+  '@valkey/valkey-glide-linux-arm64-gnu@2.0.1':
     optional: true
 
-  '@valkey/valkey-glide-linux-arm64-musl@2.0.0':
+  '@valkey/valkey-glide-linux-arm64-musl@2.0.1':
     optional: true
 
-  '@valkey/valkey-glide-linux-x64-gnu@2.0.0':
+  '@valkey/valkey-glide-linux-x64-gnu@2.0.1':
     optional: true
 
-  '@valkey/valkey-glide-linux-x64-musl@2.0.0':
+  '@valkey/valkey-glide-linux-x64-musl@2.0.1':
     optional: true
 
-  '@valkey/valkey-glide@2.0.0':
+  '@valkey/valkey-glide@2.0.1':
     dependencies:
       long: 5.3.2
       protobufjs: 7.5.3
     optionalDependencies:
-      '@valkey/valkey-glide-darwin-arm64': 2.0.0
-      '@valkey/valkey-glide-darwin-x64': 2.0.0
-      '@valkey/valkey-glide-linux-arm64-gnu': 2.0.0
-      '@valkey/valkey-glide-linux-arm64-musl': 2.0.0
-      '@valkey/valkey-glide-linux-x64-gnu': 2.0.0
-      '@valkey/valkey-glide-linux-x64-musl': 2.0.0
+      '@valkey/valkey-glide-darwin-arm64': 2.0.1
+      '@valkey/valkey-glide-darwin-x64': 2.0.1
+      '@valkey/valkey-glide-linux-arm64-gnu': 2.0.1
+      '@valkey/valkey-glide-linux-arm64-musl': 2.0.1
+      '@valkey/valkey-glide-linux-x64-gnu': 2.0.1
+      '@valkey/valkey-glide-linux-x64-musl': 2.0.1
 
   '@vitest/expect@3.1.4':
     dependencies:


### PR DESCRIPTION
## 🚀 Summary

This PR updates the `@valkey/valkey-glide` dependency from version `2.0.0` to version `2.0.1` across the project.

## ✏️ Changes

- **Dependency Update:** Upgraded `@valkey/valkey-glide` from `2.0.0` to `2.0.1`

