### PR TITLE
ci: conditionally skip `build-and-push-image` job based on commit 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,10 +7,6 @@ concurrency:
 on:
   pull_request:
     branches: ['*']
-    paths-ignore:
-      - .gitignore
-      - LICENSE
-      - README.md
 
 permissions:
   contents: read
@@ -124,6 +120,8 @@ jobs:
     name: Build and push image
     runs-on: ubuntu-latest
     needs: [test]
+    if: |
+      !contains(github.event.head_commit.message, '[skip build]')
     strategy:
       matrix:
         include:


### PR DESCRIPTION


## 🚀 Summary

This PR adds conditional execution for the `build-and-push-image` job in the CI workflow. The job will now be skipped when the commit message contains the `[skip build]` keyword, allowing us to save time and resources during development while still running other CI checks. This is particularly useful for commits that don't affect the build process (e.g. documentation updates, test improvements, or code formatting changes).

## ✏️ Changes

- Added conditional if statement to the `build-and-push-image` job to skip execution when commit message contains `[skip build]`
- Removed unnecessary `paths-ignore` section

## 📝 Notes

- `format`, `lint`, `check` and `test` jobs will still run