### PR TITLE
ci: add `scope` to `cache-from` and `cache-to` options when building container images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -165,5 +165,5 @@ jobs:
           push: true
           platforms: linux/arm64
           tags: ${{ steps.metadata.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.app }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.app }}


### PR DESCRIPTION
## 🚀 Summary

This PR adds the `scope` parameter to the `cache-from` and `cache-to` options in the `Build and push image` step of the `build-and-push-image` job. By defining a proper scope for each app, we can now cache layers independently for both applications, ensuring that each app's build process benefits from its own dedicated cache without interference from the other app's layers. This change improves docker layer caching efficiency and can help reduce build times and improve CI/CD performance.

## ✏️ Changes

- Added `scope` parameter to `cache-from` and `cache-to` in the `Build and push image` step

