### PR TITLE
feat(learner): add default error page for 404 and other errors

### DIFF
--- a/apps/learner/src/routes/+error.svelte
+++ b/apps/learner/src/routes/+error.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { page } from '$app/state';
+
+  const is404 = page.status === 404;
+</script>
+
+<div class="flex h-full flex-col items-center justify-center gap-y-4 px-6 py-5">
+  <div class="flex flex-col items-center gap-y-1">
+    <h1 class="text-3xl font-bold">
+      {is404 ? 'Page not found' : 'Something went wrong'}
+    </h1>
+    <p class="text-sm text-slate-500">
+      {is404 ? 'The page you are looking for does not exist.' : 'Please try again later.'}
+    </p>
+  </div>
+
+  <a href="/" class="rounded-full bg-slate-950 px-4 py-3 text-sm text-white">Go to Home</a>
+</div>


### PR DESCRIPTION
## 🚀 Summary

Added a default error page to the learner application to handle 404 (Not Found) and other unexpected errors. The error page informs users when something goes wrong and provides a clear call-to-action (CTA) button to navigate back to the home page, improving the overall user experience.

## ✏️ Changes

- Added `+error.svelte` as the default error page
