### PR TITLE
create(learner): update threads table

### DIFF
--- a/prisma/migrations/20250624084547_update_threads_table/migration.sql
+++ b/prisma/migrations/20250624084547_update_threads_table/migration.sql
@@ -1,0 +1,21 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `collections_id` on the `threads` table. All the data in the column will be lost.
+  - You are about to drop the column `learning_journeys_id` on the `threads` table. All the data in the column will be lost.
+  - Added the required column `user_id` to the `threads` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "threads" DROP CONSTRAINT "threads_collections_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "threads" DROP CONSTRAINT "threads_learning_journeys_id_fkey";
+
+-- AlterTable
+ALTER TABLE "threads" DROP COLUMN "collections_id",
+DROP COLUMN "learning_journeys_id",
+ADD COLUMN     "user_id" BIGINT NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "threads" ADD CONSTRAINT "threads_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,7 @@ model User {
   // Relations.
   collections      Collection[]
   learningJourneys LearningJourney[]
+  threads          Thread[]
 
   @@map("users")
 }
@@ -40,7 +41,6 @@ model Collection {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   learningJourneys LearningJourney[]
-  threads          Thread[]
 
   @@map("collections")
 }
@@ -81,8 +81,6 @@ model LearningJourney {
   multiLearningUnit MultiLearningUnit @relation(fields: [multiLearningUnitId], references: [id])
   collection        Collection        @relation(fields: [collectionId], references: [id])
 
-  threads Thread[]
-
   @@map("learning_journeys")
 }
 
@@ -95,11 +93,9 @@ model Thread {
   isActive Boolean @default(false) @map("is_active")
 
   // Relations.
-  learningJourneyId BigInt? @map("learning_journeys_id")
-  collectionId      BigInt? @map("collections_id")
+  userId BigInt @map("user_id")
 
-  learningJourney LearningJourney? @relation(fields: [learningJourneyId], references: [id])
-  collection      Collection?      @relation(fields: [collectionId], references: [id])
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   messages Message[]
 


### PR DESCRIPTION
## 🚀 Summary

This PR introduces updates to the `Threads` table in the database schema.


## ✏️ Changes

- Added a new `user_id` field to the `Threads` model.
- Removed `learning_journeys_id` and `collections_id` from `Threads` model.