### PR TITLE
create(learner): create question answers table 

### DIFF
--- a/prisma/migrations/20250624091154_create_question_answers_table/migration.sql
+++ b/prisma/migrations/20250624091154_create_question_answers_table/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "question_answers" (
+    "id" BIGSERIAL NOT NULL,
+    "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3) NOT NULL,
+    "question" TEXT NOT NULL,
+    "options" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "answer" SMALLINT NOT NULL,
+    "explanation" TEXT NOT NULL,
+    "order" SMALLINT NOT NULL,
+    "multi_learning_units_id" BIGINT NOT NULL,
+
+    CONSTRAINT "question_answers_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "question_answers" ADD CONSTRAINT "question_answers_multi_learning_units_id_fkey" FOREIGN KEY ("multi_learning_units_id") REFERENCES "multi_learning_units"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -59,6 +59,7 @@ model MultiLearningUnit {
 
   // Relations.
   learningJourneys LearningJourney[]
+  questionAnswers  QuestionAnswer[]
 
   @@map("multi_learning_units")
 }
@@ -122,4 +123,24 @@ model Message {
 enum Role {
   USER
   ASSISTANT
+}
+
+model QuestionAnswer {
+  id        BigInt   @id @default(autoincrement()) @map("id")
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  // Domain-Specific Fields.
+  question    String   @map("question")
+  options     String[] @default([]) @map("options")
+  answer      Int      @map("answer") @db.SmallInt
+  explanation String   @map("explanation")
+  order       Int      @map("order") @db.SmallInt
+
+  // Relations.
+  multiLearningUnitId BigInt @map("multi_learning_units_id")
+
+  multiLearningUnit MultiLearningUnit @relation(fields: [multiLearningUnitId], references: [id])
+
+  @@map("question_answers")
 }


### PR DESCRIPTION
## 🚀 Summary

This PR introduces the `QuestionAnswers` table to support storing questions and answers for quizzes. The table includes fields for the question text, possible options, correct answer, explanation, and order, along with a relation to the `MultiLearningUnits` table.

## ✏️ Changes

- Added a new `QuestionAnswers` table to the database schema.
- Fields include:
  - `id`: Primary key.
  - `question`: Stores the question text.
  - `options`: Array of possible answers.
  - `answer`: Index of the correct answer (stored as SMALLINT).
  - `explanation`: Optional explanation for the answer.
  - `order`: Position of the question in the quiz (stored as SMALLINT).
  - `multiLearningUnitId`: Foreign key relation to the MultiLearningUnit table.
  - Updated Prisma schema to include `@db.SmallInt `for `answer` and `order`.

## 📝 Notes

**Future Improvements:**

- Add support for multiple correct answers if needed.
- Known Limitations: The answer field currently supports only a single correct answer.
