### PR TITLE
chore(learner): remove `onDelete` cascade on user relations

### DIFF
--- a/prisma/migrations/20250625032022_remove_ondelete_cascade_on_relations/migration.sql
+++ b/prisma/migrations/20250625032022_remove_ondelete_cascade_on_relations/migration.sql
@@ -1,0 +1,17 @@
+-- DropForeignKey
+ALTER TABLE "collections" DROP CONSTRAINT "collections_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "learning_journeys" DROP CONSTRAINT "learning_journeys_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "threads" DROP CONSTRAINT "threads_user_id_fkey";
+
+-- AddForeignKey
+ALTER TABLE "collections" ADD CONSTRAINT "collections_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "learning_journeys" ADD CONSTRAINT "learning_journeys_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "threads" ADD CONSTRAINT "threads_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,7 +38,7 @@ model Collection {
   // Relations.
   userId BigInt @map("user_id")
 
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [userId], references: [id])
 
   learningJourneys LearningJourney[]
 
@@ -78,7 +78,7 @@ model LearningJourney {
   multiLearningUnitId BigInt @map("multi_learning_units_id")
   collectionId        BigInt @map("collection_id")
 
-  user              User              @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user              User              @relation(fields: [userId], references: [id])
   multiLearningUnit MultiLearningUnit @relation(fields: [multiLearningUnitId], references: [id])
   collection        Collection        @relation(fields: [collectionId], references: [id])
 
@@ -96,7 +96,7 @@ model Thread {
   // Relations.
   userId BigInt @map("user_id")
 
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [userId], references: [id])
 
   messages Message[]
 


### PR DESCRIPTION
## 🚀 Summary

Removed the `onDelete` behavior from foreign key constraints on user relations in the `collections`, `learning_journeys`, and `threads` tables. This change prevents cascading deletions of related records when a `user` is deleted, improving data integrity and avoiding unintentional data loss.

## ✏️ Changes

- Removed `onDelete`: Cascade from the `user_id` foreign key in the `collections`, `learning_journeys`, and `threads` tables.
- Updated the schema to ensure related records (e.g., `collections`, `learning_journeys`, `threads`) are not automatically deleted when a `user` is removed.

## 📝 Notes

- Breaking Change: Deleting a `user` now requires manual handling of related records in child tables to avoid foreign key constraint errors.
- Future improvements could include implementing soft deletes or additional logic at the application level to handle related records when a user is deleted.
