### PR TITLE
chore(learner): add `tag` field to collection table

### DIFF
--- a/prisma/migrations/20250625093427_add_tags_to_collection_table/migration.sql
+++ b/prisma/migrations/20250625093427_add_tags_to_collection_table/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `tag` to the `collections` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "collections" ADD COLUMN     "tag" VARCHAR(255) NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,6 +34,7 @@ model Collection {
   // Domain-Specific Fields.
   kind  String @map("kind") @db.VarChar(255)
   title String @map("title")
+  tag   String @map("tag") @db.VarChar(255)
 
   // Relations.
   userId BigInt @map("user_id")


### PR DESCRIPTION
## 🚀 Summary

This migration adds a new `tag` column to the `collection` table in the database. The `tag` column will store metadata or categorization tag associated with each collection. This change supports future features requiring tag-based filtering or grouping.

## ✏️ Changes

- Added a `tag` column to the `collection` table in the database.
  - Type: `String`
  - Mapped to a `VARCHAR(255)` in the database.
- Updated the Prisma schema to include the `tag` field in the `Collection` model.

## 📝 Notes

- The `tag` field is currently a single string. Future enhancements could include storing tags as an array or JSON object for more flexible usage.