### PR TITLE
chore: rename model fields from `content_type` to `contentType` and `content_url` to `contentURL`

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -52,11 +52,11 @@ model MultiLearningUnit {
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
 
   // Domain-Specific Fields.
-  title        String   @map("title")
-  collection   String   @map("collection") @db.VarChar(255)
-  tags         String[] @default([]) @map("tags") @db.VarChar(255)
-  content_type String   @map("content_type") @db.VarChar(255)
-  content_url  String   @map("content_url")
+  title       String   @map("title")
+  collection  String   @map("collection") @db.VarChar(255)
+  tags        String[] @default([]) @map("tags") @db.VarChar(255)
+  contentType String   @map("content_type") @db.VarChar(255)
+  contentURL  String   @map("content_url")
 
   // Relations.
   learningJourneys LearningJourney[]


### PR DESCRIPTION
## 🚀 Summary

This PR standardises the naming convention for model fields by converting `snake_case` to `camelCase`. Specifically, it renames `content_type` to `contentType` and `content_url` to `contentURL` to maintain consistency with JavaScript/TypeScript naming conventions throughout the codebase.


## ✏️ Changes

- Renamed model field `content_type` to `contentType`
- Renamed model field `content_url` to `contentURL`

## 📝 Notes

- No migration file was generated because the database schema remains unchanged.
