### PR TITLE
chore: update relations between `Collection`, `MultiLearningUnit` and `LearningJourney`

### DIFF
--- a/prisma/migrations/20250625205026_relink_relation_between_collection_mlu_lj/migration.sql
+++ b/prisma/migrations/20250625205026_relink_relation_between_collection_mlu_lj/migration.sql
@@ -1,0 +1,20 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `collection_id` on the `learning_journeys` table. All the data in the column will be lost.
+  - You are about to drop the column `collection` on the `multi_learning_units` table. All the data in the column will be lost.
+  - Added the required column `collection_id` to the `multi_learning_units` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "learning_journeys" DROP CONSTRAINT "learning_journeys_collection_id_fkey";
+
+-- AlterTable
+ALTER TABLE "learning_journeys" DROP COLUMN "collection_id";
+
+-- AlterTable
+ALTER TABLE "multi_learning_units" DROP COLUMN "collection",
+ADD COLUMN     "collection_id" BIGINT NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "multi_learning_units" ADD CONSTRAINT "multi_learning_units_collection_id_fkey" FOREIGN KEY ("collection_id") REFERENCES "collections"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,9 +39,8 @@ model Collection {
   // Relations.
   userId BigInt @map("user_id")
 
-  user User @relation(fields: [userId], references: [id])
-
-  learningJourneys LearningJourney[]
+  user              User                @relation(fields: [userId], references: [id])
+  multiLearningUnit MultiLearningUnit[]
 
   @@map("collections")
 }
@@ -53,12 +52,14 @@ model MultiLearningUnit {
 
   // Domain-Specific Fields.
   title       String   @map("title")
-  collection  String   @map("collection") @db.VarChar(255)
   tags        String[] @default([]) @map("tags") @db.VarChar(255)
   contentType String   @map("content_type") @db.VarChar(255)
   contentURL  String   @map("content_url")
 
   // Relations.
+  collectionId BigInt @map("collection_id")
+
+  collection       Collection        @relation(fields: [collectionId], references: [id])
   learningJourneys LearningJourney[]
   questionAnswers  QuestionAnswer[]
 
@@ -77,11 +78,9 @@ model LearningJourney {
   // Relations.
   userId              BigInt @map("user_id")
   multiLearningUnitId BigInt @map("multi_learning_units_id")
-  collectionId        BigInt @map("collection_id")
 
   user              User              @relation(fields: [userId], references: [id])
   multiLearningUnit MultiLearningUnit @relation(fields: [multiLearningUnitId], references: [id])
-  collection        Collection        @relation(fields: [collectionId], references: [id])
 
   @@map("learning_journeys")
 }


### PR DESCRIPTION
## 🚀 Summary

This PR refactors the database schema to improve the relationship structure between `Collections`, `MultiLearningUnits`, and `LearningJourneys`. The changes simplify the data model by removing redundant relationships and establishing a cleaner hierarchical structure where `LearningJourneys` can access `Collection` information through `MultiLearningUnits`.

## ✏️ Changes

- **Removed redundant relationship:** Eliminated the direct link between `Collection` and `LearningJourney` tables since this relationship can be established through `MultiLearningUnit`
- **Updated `MultiLearningUnit` schema:** Removed the `collectionId` column from `MultiLearningUnit` table and replaced it with a proper foreign key relationship to `Collection`
- **Improved data access pattern:** LearningJourney can now join with MultiLearningUnit and Collection to retrieve all necessary information through the established relationship chain

## 📝 Notes

- A database reset may be required before applying a fresh migration.
