### PR TITLE
chore: rename `is_completed` to `isCompleted` and `last_checkpoint` to `lastCheckpoint`

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -71,8 +71,8 @@ model LearningJourney {
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
 
   // Domain-Specific Fields.
-  is_completed    Boolean @default(false) @map("is_completed")
-  last_checkpoint Decimal @map("last_checkpoint")
+  isCompleted    Boolean @default(false) @map("is_completed")
+  lastCheckpoint Decimal @map("last_checkpoint")
 
   // Relations.
   userId              BigInt @map("user_id")


### PR DESCRIPTION
## 🚀 Summary

This PR standardises the naming convention for model fields by converting snake_case to camelCase. Specifically, it renames `is_completed` to `isCompleted` and `last_checkpoint` to `lastCheckpoint` to maintain consistency with JavaScript/TypeScript naming conventions throughout the codebase.


## ✏️ Changes

- Renamed model field `is_completed` to `isCompleted`
- Renamed model field `last_checkpoint` to `lastCheckpoint`

## 📝 Notes

- No migration file was generated because the database schema remains unchanged.
