### PR TITLE
chore(deps): bump `eslint-plugin-svelte` from `3.9.3` to `3.10.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@eslint/js": "^9.30.0",
     "eslint": "^9.30.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
-    "eslint-plugin-svelte": "^3.9.3",
+    "eslint-plugin-svelte": "^3.10.1",
     "globals": "^16.2.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ importers:
         specifier: ^12.1.1
         version: 12.1.1(eslint@9.30.0(jiti@2.4.2))
       eslint-plugin-svelte:
-        specifier: ^3.9.3
-        version: 3.9.3(eslint@9.30.0(jiti@2.4.2))(svelte@5.33.4)
+        specifier: ^3.10.1
+        version: 3.10.1(eslint@9.30.0(jiti@2.4.2))(svelte@5.33.4)
       globals:
         specifier: ^16.2.0
         version: 16.2.0
@@ -1084,8 +1084,8 @@ packages:
     peerDependencies:
       eslint: '>=5.0.0'
 
-  eslint-plugin-svelte@3.9.3:
-    resolution: {integrity: sha512-PlcyK80sqAZ43IITeZkgl3zPFWJytx/Joup9iKGqIOsXM2m3pWfPbWuXPr5PN3loXFEypqTY/JyZwNqlSpSvRw==}
+  eslint-plugin-svelte@3.10.1:
+    resolution: {integrity: sha512-csCh2x0ge/DugXC7dCANh46Igi7bjMZEy6rHZCdS13AoGVJSu7a90Kru3I8oMYLGEemPRE1hQXadxvRPVMAAXQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.1 || ^9.0.0
@@ -2824,7 +2824,7 @@ snapshots:
     dependencies:
       eslint: 9.30.0(jiti@2.4.2)
 
-  eslint-plugin-svelte@3.9.3(eslint@9.30.0(jiti@2.4.2))(svelte@5.33.4):
+  eslint-plugin-svelte@3.10.1(eslint@9.30.0(jiti@2.4.2))(svelte@5.33.4):
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.30.0(jiti@2.4.2))
       '@jridgewell/sourcemap-codec': 1.5.0


### PR DESCRIPTION
## 🚀 Summary

This PR updates the `eslint-plugin-svelte` dependency from version `3.9.3` to version `3.10.1` across the project.

## ✏️ Changes

- **Dependency Update:** Upgraded `eslint-plugin-svelte` from `3.9.3` to `3.10.1`