### PR TITLE
chore(deps): bump `prettier` from `3.5.3` to `3.6.2`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,6 @@ We enthusiastically welcome code contributions via Pull Requests (PRs)! If you'r
 1. **Discuss First (for significant changes):** If you're proposing a major change, new feature, or significant refactoring, please [open an issue](https://github.com/string-sg/onward/issues/new) first to discuss the approach and ensure it aligns with the project's goals. For smaller bug fixes, feel free to go straight to a PR.
 
 2. **Fork & Branch:**
-
    - Fork the repository on GitHub.
    - Clone your fork locally.
    - Create a descriptive branch from the `main` branch. Good branch names include the type of change and a short description (e.g. `fix/login-bug`, `feat/add-user-profile`, `docs/update-readme`).
@@ -42,12 +41,10 @@ We enthusiastically welcome code contributions via Pull Requests (PRs)! If you'r
 3. **Set Up Environment:** Follow the instructions in the [Development Setup](#development-setup) section to prepare your local environment.
 
 4. **Implement Changes:**
-
    - Write your code, adhering to the guidelines in the [Code Style Guidelines](#code-style-guidelines) section.
    - Ensure your changes address the intended issue or feature.
 
 5. **Write Tests:**
-
    - Add relevant unit or integration tests for any new functionality or bug fixes. We aim for good test coverage to maintain stability.
    - Ensure all tests pass by running:
      ```sh
@@ -57,7 +54,6 @@ We enthusiastically welcome code contributions via Pull Requests (PRs)! If you'r
 6. **Update Documentation:** If your changes affect user-facing features, internal APIs, or the development process, please update the relevant documentation (e.g. README, specific docs pages).
 
 7. **Commit Changes:**
-
    - Keep your commits logical and atomic.
    - Write clear and concise commit messages. We recommend following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification (e.g. `fix: correct typo in contribution guide`, `feat: add user authentication`). This helps automate release notes and makes the history easier to understand.
    - Remember that `husky` hooks will run `lint-staged` and potentially other checks (like type checking on push) automatically.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "globals": "^16.2.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.1.0",
-    "prettier": "^3.5.3",
+    "prettier": "^3.6.2",
     "prettier-plugin-svelte": "^3.4.0",
     "prettier-plugin-tailwindcss": "^0.6.11",
     "prisma": "^6.8.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,14 +35,14 @@ importers:
         specifier: ^16.1.0
         version: 16.1.0
       prettier:
-        specifier: ^3.5.3
-        version: 3.5.3
+        specifier: ^3.6.2
+        version: 3.6.2
       prettier-plugin-svelte:
         specifier: ^3.4.0
-        version: 3.4.0(prettier@3.5.3)(svelte@5.33.4)
+        version: 3.4.0(prettier@3.6.2)(svelte@5.33.4)
       prettier-plugin-tailwindcss:
         specifier: ^0.6.11
-        version: 0.6.11(prettier-plugin-svelte@3.4.0(prettier@3.5.3)(svelte@5.33.4))(prettier@3.5.3)
+        version: 0.6.11(prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.33.4))(prettier@3.6.2)
       prisma:
         specifier: ^6.8.2
         version: 6.8.2(typescript@5.8.3)
@@ -1656,8 +1656,8 @@ packages:
       prettier-plugin-svelte:
         optional: true
 
-  prettier@3.5.3:
-    resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
+  prettier@3.6.2:
+    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -3293,18 +3293,18 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-svelte@3.4.0(prettier@3.5.3)(svelte@5.33.4):
+  prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.33.4):
     dependencies:
-      prettier: 3.5.3
+      prettier: 3.6.2
       svelte: 5.33.4
 
-  prettier-plugin-tailwindcss@0.6.11(prettier-plugin-svelte@3.4.0(prettier@3.5.3)(svelte@5.33.4))(prettier@3.5.3):
+  prettier-plugin-tailwindcss@0.6.11(prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.33.4))(prettier@3.6.2):
     dependencies:
-      prettier: 3.5.3
+      prettier: 3.6.2
     optionalDependencies:
-      prettier-plugin-svelte: 3.4.0(prettier@3.5.3)(svelte@5.33.4)
+      prettier-plugin-svelte: 3.4.0(prettier@3.6.2)(svelte@5.33.4)
 
-  prettier@3.5.3: {}
+  prettier@3.6.2: {}
 
   prisma@6.8.2(typescript@5.8.3):
     dependencies:


### PR DESCRIPTION
## 🚀 Summary

This PR updates the `prettier` dependency from version `3.5.3` to version `3.6.2` across the project.

## ✏️ Changes

- **Dependency Update:** Upgraded `prettier` from `3.5.3` to `3.6.2`