### PR TITLE
chore(deps): update peer dependency `@valkey/valkey-glide` from `1.3.5-rc13` to `2.0.1` for `@onward/auth` package

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -22,7 +22,7 @@
     "@sveltejs/kit": "^2.22.2",
     "@sveltejs/package": "^2.3.11",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
-    "@valkey/valkey-glide": "2.0.1",
+    "@valkey/valkey-glide": "^2.0.1",
     "svelte": "^5.34.9",
     "typescript": "^5.8.3",
     "vite": "^6.3.5",
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "@sveltejs/kit": "^2.22.2",
-    "@valkey/valkey-glide": "1.3.5-rc13",
+    "@valkey/valkey-glide": "^2.0.1",
     "svelte": "^5.34.9"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,7 +142,7 @@ importers:
         specifier: ^5.0.3
         version: 5.0.3(svelte@5.34.9)(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
       '@valkey/valkey-glide':
-        specifier: 2.0.1
+        specifier: ^2.0.1
         version: 2.0.1
       svelte:
         specifier: ^5.34.9


### PR DESCRIPTION
## 🚀 Summary

This PR updates the `@valkey/valkey-glide` peer dependency from version `1.3.5-rc13` to version `2.0.1` for `@onward/auth` package.

## ✏️ Changes

- **Peer Dependency Update:** Upgraded `@valkey/valkey-glide` from `1.3.5-rc13` to `2.0.1`