### PR TITLE
chore(deps): bump `svelte-check` from `4.2.1` to `4.2.2`

### DIFF
--- a/apps/creator/package.json
+++ b/apps/creator/package.json
@@ -16,7 +16,7 @@
     "@sveltejs/vite-plugin-svelte": "^5.1.0",
     "@tailwindcss/vite": "^4.1.11",
     "svelte": "^5.34.9",
-    "svelte-check": "^4.2.1",
+    "svelte-check": "^4.2.2",
     "tailwindcss": "^4.1.11",
     "typescript": "^5.8.3",
     "vite": "^6.3.5"

--- a/apps/learner/package.json
+++ b/apps/learner/package.json
@@ -22,7 +22,7 @@
     "@sveltejs/vite-plugin-svelte": "^5.1.0",
     "@tailwindcss/vite": "^4.1.11",
     "svelte": "^5.34.9",
-    "svelte-check": "^4.2.1",
+    "svelte-check": "^4.2.2",
     "tailwindcss": "^4.1.11",
     "typescript": "^5.8.3",
     "vite": "^6.3.5"

--- a/patches/svelte-check.patch
+++ b/patches/svelte-check.patch
@@ -1,8 +1,8 @@
 diff --git a/dist/src/index.js b/dist/src/index.js
-index 16d4a342662255a40d9c1c2b6eb36ff3441458cd..883a8863055e3ca366fee50b7afb3f8fb8befb7e 100644
+index 53d21bd957dd4d3cb6ccd6c67a51d9dab137bd4c..de82ef78851949f8e8aabad9c0133e04f35a892f 100644
 --- a/dist/src/index.js
 +++ b/dist/src/index.js
-@@ -131416,10 +131416,7 @@ class HumanFriendlyWriter {
+@@ -131633,10 +131633,7 @@ class HumanFriendlyWriter {
              process.stdout.clearScreenDown();
          }
          if (this.isVerbose) {
@@ -14,7 +14,7 @@ index 16d4a342662255a40d9c1c2b6eb36ff3441458cd..883a8863055e3ca366fee50b7afb3f8f
              this.stream.write('Getting Svelte diagnostics...\n');
              this.stream.write('\n');
          }
-@@ -131433,7 +131430,7 @@ class HumanFriendlyWriter {
+@@ -131650,7 +131647,7 @@ class HumanFriendlyWriter {
              let msg;
              if (this.isVerbose) {
                  const code = this.formatRelatedCode(diagnostic, text);
@@ -23,7 +23,7 @@ index 16d4a342662255a40d9c1c2b6eb36ff3441458cd..883a8863055e3ca366fee50b7afb3f8f
              }
              else {
                  msg = `${diagnostic.message} ${source}`;
-@@ -131470,7 +131467,6 @@ class HumanFriendlyWriter {
+@@ -131687,7 +131684,6 @@ class HumanFriendlyWriter {
          return text.substring(src.offsetAt({ line, character: 0 }, text), src.offsetAt({ line, character: Number.MAX_SAFE_INTEGER }, text));
      }
      completion(_f, errorCount, warningCount, fileCountWithProblems) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   svelte-check:
-    hash: 702b6df5109786a8c91060cb8a07b270125987bf3e630593103476778a49f173
+    hash: 01129bdf6de4a986e0a01cfa8aff0ce4a34801979b0e21a10bc1936da07e4504
     path: patches/svelte-check.patch
 
 importers:
@@ -68,8 +68,8 @@ importers:
         specifier: ^5.34.9
         version: 5.34.9
       svelte-check:
-        specifier: ^4.2.1
-        version: 4.2.1(patch_hash=702b6df5109786a8c91060cb8a07b270125987bf3e630593103476778a49f173)(picomatch@4.0.2)(svelte@5.34.9)(typescript@5.8.3)
+        specifier: ^4.2.2
+        version: 4.2.2(patch_hash=01129bdf6de4a986e0a01cfa8aff0ce4a34801979b0e21a10bc1936da07e4504)(picomatch@4.0.2)(svelte@5.34.9)(typescript@5.8.3)
       tailwindcss:
         specifier: ^4.1.11
         version: 4.1.11
@@ -111,8 +111,8 @@ importers:
         specifier: ^5.34.9
         version: 5.34.9
       svelte-check:
-        specifier: ^4.2.1
-        version: 4.2.1(patch_hash=702b6df5109786a8c91060cb8a07b270125987bf3e630593103476778a49f173)(picomatch@4.0.2)(svelte@5.34.9)(typescript@5.8.3)
+        specifier: ^4.2.2
+        version: 4.2.2(patch_hash=01129bdf6de4a986e0a01cfa8aff0ce4a34801979b0e21a10bc1936da07e4504)(picomatch@4.0.2)(svelte@5.34.9)(typescript@5.8.3)
       tailwindcss:
         specifier: ^4.1.11
         version: 4.1.11
@@ -1174,6 +1174,14 @@ packages:
       picomatch:
         optional: true
 
+  fdir@6.4.6:
+    resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -1782,8 +1790,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  svelte-check@4.2.1:
-    resolution: {integrity: sha512-e49SU1RStvQhoipkQ/aonDhHnG3qxHSBtNfBRb9pxVXoa+N7qybAo32KgA9wEb2PCYFNaDg7bZCdhLD1vHpdYA==}
+  svelte-check@4.2.2:
+    resolution: {integrity: sha512-1+31EOYZ7NKN0YDMKusav2hhEoA51GD9Ws6o//0SphMT0ve9mBTsTUEX7OmDMadUP3KjNHsSKtJrqdSaD8CrGQ==}
     engines: {node: '>= 18.0.0'}
     hasBin: true
     peerDependencies:
@@ -2943,6 +2951,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.2
 
+  fdir@6.4.6(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -3435,11 +3447,11 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@4.2.1(patch_hash=702b6df5109786a8c91060cb8a07b270125987bf3e630593103476778a49f173)(picomatch@4.0.2)(svelte@5.34.9)(typescript@5.8.3):
+  svelte-check@4.2.2(patch_hash=01129bdf6de4a986e0a01cfa8aff0ce4a34801979b0e21a10bc1936da07e4504)(picomatch@4.0.2)(svelte@5.34.9)(typescript@5.8.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 4.0.3
-      fdir: 6.4.4(picomatch@4.0.2)
+      fdir: 6.4.6(picomatch@4.0.2)
       picocolors: 1.1.1
       sade: 1.8.1
       svelte: 5.34.9


### PR DESCRIPTION
## 🚀 Summary

This PR updates the `svelte-check` dependency from version `4.2.1` to version `4.2.2` across the project.

## ✏️ Changes

- **Dependency Update:** Upgraded `svelte-check` from `4.2.1` to `4.2.2`