### PR TITLE
feat(learner): add quiz page with hardcoded data

### DIFF
--- a/apps/learner/src/routes/content/[id]/quiz/+page.server.ts
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.server.ts
@@ -1,0 +1,23 @@
+export const load = async () => {
+  return {
+    title:
+      'The quick brown fox jumps over the lazy dog The quick brown fox jumps over the lazy dog',
+    questionAnswers: [
+      {
+        id: 123,
+        question: 'The quick brown fox jumps over the lazy dog ',
+        options: ['The quick', 'brown fox jumps', 'over the', 'lazy dog'],
+        answer: 2,
+        explanation: 'This is an explanation.',
+      },
+      {
+        id: 234,
+        question:
+          'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor',
+        options: ['Lorem', 'ipsum', 'dolor', 'sit amet'],
+        answer: 2,
+        explanation: 'This is an explanation.',
+      },
+    ],
+  };
+};

--- a/apps/learner/src/routes/content/[id]/quiz/+page.server.ts
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.server.ts
@@ -1,4 +1,6 @@
-export const load = async () => {
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async () => {
   return {
     title:
       'The quick brown fox jumps over the lazy dog The quick brown fox jumps over the lazy dog',

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { ArrowLeft } from '@lucide/svelte';
 
-  import { goto } from '$app/navigation';
   import { page } from '$app/state';
 
   const { data } = $props();
@@ -32,52 +31,59 @@
       }
     }
   }
-
-  function goBack() {
-    goto(`/content/${contentId}`);
-  }
 </script>
 
 <main class="mx-auto flex h-full w-full max-w-5xl flex-col">
-  <div class="align-center flex justify-between px-6 py-5">
-    <button
-      class="align-center flex cursor-pointer gap-1 rounded-full bg-slate-200 p-2"
-      onclick={() => goBack()}
+  <div class="item-center flex justify-between px-6 py-5">
+    <a
+      href="/content/{contentId}"
+      class="item-center cursor-pointer items-center rounded-[100px] bg-slate-200 px-3 py-4"
     >
       <ArrowLeft />
-    </button>
-  </div>
-  <div class="px-6 text-xl font-medium">{currentQuestion.question}</div>
-  <div class="flex flex-col items-start gap-2 px-6 pt-6">
-    {#each currentQuestion.options as option, index (option)}
-      <button
-        class="flex h-16 cursor-pointer items-center gap-3 self-stretch rounded-2xl bg-white p-3 {selectedOptionIndex ===
-        index
-          ? 'border border-black'
-          : ''}"
-        onclick={() => selectOption(index)}
-      >
-        <div
-          class="flex items-center justify-center gap-1 rounded-lg {selectedOptionIndex === index
-            ? 'bg-slate-900 text-white'
-            : 'bg-slate-100'} px-2 py-1"
-        >
-          {getOptionLetter(index)}
-        </div>
-        {option}
-      </button>
-    {/each}
+    </a>
   </div>
 
-  <div class="py-9.5 mt-auto flex flex-col px-6">
-    <button
-      class="flex justify-center gap-1 rounded-full {selectedOptionIndex === -1
-        ? ' cursor-not-allowed bg-slate-900/[0.5]'
-        : 'cursor-pointer bg-slate-900'} px-1 py-4 text-white"
-      onclick={nextQuestion}
-      disabled={selectedOptionIndex === -1}
-    >
-      Check Answer
-    </button>
+  <div class="flex h-full flex-col px-6">
+    <div class="flex-1">
+      <span class="text-xl font-medium">{currentQuestion.question}</span>
+      <div class="flex flex-col items-start gap-y-2 pt-6">
+        {#each currentQuestion.options as option, index (option)}
+          <button
+            class={[
+              selectedOptionIndex === index && 'border border-black',
+              'flex w-full cursor-pointer items-center gap-3 rounded-2xl bg-white p-3',
+            ]}
+            onclick={() => selectOption(index)}
+          >
+            <span
+              class={[
+                selectedOptionIndex === index ? 'bg-slate-900 text-white' : 'bg-slate-100',
+                'flex items-center justify-center rounded-lg px-2 py-1 text-xs',
+              ]}
+            >
+              {getOptionLetter(index)}
+            </span>
+            <span class="text-sm">
+              {option}
+            </span>
+          </button>
+        {/each}
+      </div>
+    </div>
+
+    <div class="py-9.5 mt-auto">
+      <button
+        class={[
+          selectedOptionIndex === -1
+            ? ' cursor-not-allowed bg-slate-900/[0.5]'
+            : 'cursor-pointer bg-slate-900',
+          'flex w-full justify-center rounded-full px-1 py-4 text-white',
+        ]}
+        onclick={nextQuestion}
+        disabled={selectedOptionIndex === -1}
+      >
+        Check Answer
+      </button>
+    </div>
   </div>
 </main>

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -58,7 +58,7 @@
             <span
               class={[
                 selectedOptionIndex === index ? 'bg-slate-900 text-white' : 'bg-slate-100',
-                'flex items-center justify-center rounded-lg px-2 py-1 text-xs',
+                'flex items-center justify-center rounded-lg px-2 py-1 text-xs font-semibold',
               ]}
             >
               {getOptionLetter(index)}

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -35,12 +35,11 @@
 
 <main class="mx-auto flex h-full w-full max-w-5xl flex-col">
   <div class="flex items-center justify-between px-6 py-5">
-    <a
-      href="/content/{contentId}"
-      class="cursor-pointer items-center rounded-[100px] bg-slate-200 px-3 py-4"
-    >
-      <ArrowLeft />
-    </a>
+    <div class="rounded-full bg-slate-200 px-3 py-4">
+      <a href="/content/{contentId}">
+        <ArrowLeft />
+      </a>
+    </div>
   </div>
 
   <div class="flex h-full flex-col px-6">

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -49,15 +49,15 @@
         {#each currentQuestion.options as option, index (option)}
           <button
             class={[
-              selectedOptionIndex === index && 'border border-black',
               'flex w-full cursor-pointer items-center gap-3 rounded-2xl bg-white p-3',
+              selectedOptionIndex === index && 'border border-black',
             ]}
             onclick={() => selectOption(index)}
           >
             <span
               class={[
-                selectedOptionIndex === index ? 'bg-slate-900 text-white' : 'bg-slate-100',
                 'flex items-center justify-center rounded-lg px-2 py-1 text-xs font-semibold',
+                selectedOptionIndex === index ? 'bg-slate-900 text-white' : 'bg-slate-100',
               ]}
             >
               {getOptionLetter(index)}
@@ -73,10 +73,8 @@
     <div class="py-9.5 mt-auto">
       <button
         class={[
-          selectedOptionIndex === -1
-            ? ' cursor-not-allowed bg-slate-900/[0.5]'
-            : 'cursor-pointer bg-slate-900',
           'flex w-full justify-center rounded-full px-1 py-4 text-white',
+          selectedOptionIndex === -1 ? ' bg-slate-900/[0.5]' : 'cursor-pointer bg-slate-900',
         ]}
         onclick={nextQuestion}
         disabled={selectedOptionIndex === -1}

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -34,35 +34,33 @@
 </script>
 
 <main class="mx-auto flex h-full w-full max-w-5xl flex-col">
-  <div class="flex items-center justify-between px-6 py-5">
-    <div class="rounded-full bg-slate-200 px-3 py-4">
-      <a href="/content/{contentId}">
+  <div class="flex h-full flex-col gap-y-6 p-6">
+    <div class="flex items-center">
+      <a class="rounded-full bg-slate-200 px-3 py-4" href="/content/{contentId}">
         <ArrowLeft />
       </a>
     </div>
-  </div>
 
-  <div class="flex h-full flex-col px-6">
-    <div class="flex-1">
+    <div class="flex flex-1 flex-col gap-y-6">
       <span class="text-xl font-medium">{currentQuestion.question}</span>
-      <div class="flex flex-col items-start gap-y-2 pt-6">
+      <div class="flex flex-col items-start gap-y-2">
         {#each currentQuestion.options as option, index (option)}
           <button
             class={[
-              'flex w-full cursor-pointer items-center gap-x-3 rounded-2xl bg-white p-3',
-              selectedOptionIndex === index && 'border border-black',
+              'py-4.75 px-2.75 flex w-full cursor-pointer items-center gap-x-3 rounded-2xl border border-transparent bg-white',
+              selectedOptionIndex === index && '!border-black',
             ]}
             onclick={() => selectOption(index)}
           >
             <span
               class={[
-                'flex items-center justify-center rounded-lg px-2 py-1 text-xs font-semibold',
-                selectedOptionIndex === index ? 'bg-slate-900 text-white' : 'bg-slate-100',
+                'flex items-center justify-center rounded-lg bg-slate-100 px-2 py-1 text-xs font-semibold text-black',
+                selectedOptionIndex === index && '!bg-slate-900 !text-white',
               ]}
             >
               {getOptionLetter(index)}
             </span>
-            <span class="w-full text-left text-sm">
+            <span class="text-left text-sm">
               {option}
             </span>
           </button>
@@ -70,17 +68,12 @@
       </div>
     </div>
 
-    <div class="py-9.5 mt-auto">
-      <button
-        class={[
-          'flex w-full justify-center rounded-full px-1 py-4 text-white',
-          selectedOptionIndex === -1 ? ' bg-slate-900/[0.5]' : 'cursor-pointer bg-slate-900',
-        ]}
-        onclick={nextQuestion}
-        disabled={selectedOptionIndex === -1}
-      >
-        Check Answer
-      </button>
-    </div>
+    <button
+      class="flex w-full cursor-pointer justify-center rounded-full bg-slate-900 px-1 py-4 text-white disabled:pointer-events-none disabled:opacity-50"
+      onclick={nextQuestion}
+      disabled={selectedOptionIndex === -1}
+    >
+      Check Answer
+    </button>
   </div>
 </main>

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -34,10 +34,10 @@
 </script>
 
 <main class="mx-auto flex h-full w-full max-w-5xl flex-col">
-  <div class="item-center flex justify-between px-6 py-5">
+  <div class="flex items-center justify-between px-6 py-5">
     <a
       href="/content/{contentId}"
-      class="item-center cursor-pointer items-center rounded-[100px] bg-slate-200 px-3 py-4"
+      class="cursor-pointer items-center rounded-[100px] bg-slate-200 px-3 py-4"
     >
       <ArrowLeft />
     </a>

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -49,7 +49,7 @@
         {#each currentQuestion.options as option, index (option)}
           <button
             class={[
-              'flex w-full cursor-pointer items-center gap-3 rounded-2xl bg-white p-3',
+              'flex w-full cursor-pointer items-center gap-x-3 rounded-2xl bg-white p-3',
               selectedOptionIndex === index && 'border border-black',
             ]}
             onclick={() => selectOption(index)}

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -62,7 +62,7 @@
             >
               {getOptionLetter(index)}
             </span>
-            <span class="text-sm">
+            <span class="w-full text-left text-sm">
               {option}
             </span>
           </button>

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -1,1 +1,83 @@
-<div class="px-6 py-5">Quiz page!</div>
+<script lang="ts">
+  import { ArrowLeft } from '@lucide/svelte';
+
+  import { goto } from '$app/navigation';
+  import { page } from '$app/state';
+
+  const { data } = $props();
+
+  let selectedOptionIndex = $state(-1);
+  let currentQuestionIndex = $state(0);
+
+  let currentQuestion = $derived(data.questionAnswers[currentQuestionIndex]);
+
+  const contentId = $derived(page.params.id);
+
+  function selectOption(index: number) {
+    selectedOptionIndex = index;
+  }
+
+  function getOptionLetter(index: number) {
+    return String.fromCharCode(65 + index);
+  }
+
+  function nextQuestion() {
+    if (selectedOptionIndex !== -1) {
+      if (currentQuestionIndex < data.questionAnswers.length - 1) {
+        currentQuestionIndex++;
+        selectedOptionIndex = -1;
+      } else {
+        //TODO: Redirect quiz to completion page
+        console.log('Quiz completed!');
+      }
+    }
+  }
+
+  function goBack() {
+    goto(`/content/${contentId}`);
+  }
+</script>
+
+<main class="mx-auto flex h-full w-full max-w-5xl flex-col bg-slate-100">
+  <div class="align-center flex justify-between px-6 py-5">
+    <button
+      class="align-center flex cursor-pointer gap-1 rounded-full bg-slate-200 p-2"
+      onclick={() => goBack()}
+    >
+      <ArrowLeft />
+    </button>
+  </div>
+  <div class="px-6 text-xl font-medium">{currentQuestion.question}</div>
+  <div class="flex flex-col items-start gap-2 px-6 pt-6">
+    {#each currentQuestion.options as option, index (option)}
+      <button
+        class="flex h-16 cursor-pointer items-center gap-3 self-stretch rounded-2xl bg-white p-3 {selectedOptionIndex ===
+        index
+          ? 'border border-black'
+          : ''}"
+        onclick={() => selectOption(index)}
+      >
+        <div
+          class="flex items-center justify-center gap-1 rounded-lg {selectedOptionIndex === index
+            ? 'bg-slate-900 text-white'
+            : 'bg-slate-100'} px-2 py-1"
+        >
+          {getOptionLetter(index)}
+        </div>
+        {option}
+      </button>
+    {/each}
+  </div>
+
+  <div class="py-9.5 mt-auto flex flex-col px-6">
+    <button
+      class="flex justify-center gap-1 rounded-full {selectedOptionIndex === -1
+        ? ' cursor-not-allowed bg-slate-900/[0.5]'
+        : 'cursor-pointer bg-slate-900'} px-1 py-4 text-white"
+      onclick={nextQuestion}
+      disabled={selectedOptionIndex === -1}
+    >
+      Check Answer
+    </button>
+  </div>
+</main>

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -38,7 +38,7 @@
   }
 </script>
 
-<main class="mx-auto flex h-full w-full max-w-5xl flex-col bg-slate-100">
+<main class="mx-auto flex h-full w-full max-w-5xl flex-col">
   <div class="align-center flex justify-between px-6 py-5">
     <button
       class="align-center flex cursor-pointer gap-1 rounded-full bg-slate-200 p-2"


### PR DESCRIPTION
Closes #49 

## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->
This PR adds the quiz component for learner which is rendered sequentially.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->
- added `+page.server.svelte` in `quiz` (currently values are hardcoded, will be dynamic based on content once DB integration is complete)
- updated UI design for quiz page in `+page.svelte` in `quiz`

Note: the album cover (as shown in figma) is currently not implemented as design is yet to be firmed up. 