### PR TITLE
feat(learner): add learning unit page with hardcoded data

### DIFF
--- a/apps/learner/package.json
+++ b/apps/learner/package.json
@@ -21,6 +21,7 @@
     "@sveltejs/kit": "^2.22.2",
     "@sveltejs/vite-plugin-svelte": "^5.1.0",
     "@tailwindcss/vite": "^4.1.11",
+    "date-fns": "^4.1.0",
     "svelte": "^5.34.9",
     "svelte-check": "^4.2.2",
     "tailwindcss": "^4.1.11",

--- a/apps/learner/src/routes/content/[id]/+page.server.ts
+++ b/apps/learner/src/routes/content/[id]/+page.server.ts
@@ -1,0 +1,10 @@
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async () => {
+  return {
+    id: 1,
+    title: 'Navigating Special Educational Needs: A Path to Inclusion',
+    tags: ['Special Educational Needs'],
+    createdAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
+  };
+};

--- a/apps/learner/src/routes/content/[id]/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/+page.svelte
@@ -1,1 +1,54 @@
-<div class="px-6 py-5">Learning unit content page!</div>
+<script lang="ts">
+  import { ArrowLeft, Lightbulb, Play, Share } from '@lucide/svelte';
+
+  import Badge from '$lib/components/Badge.svelte';
+</script>
+
+<div class="flex flex-col gap-y-6 p-6">
+  <div class="flex justify-between">
+    <div class="rounded-full bg-slate-200 px-3 py-4">
+      <ArrowLeft />
+    </div>
+
+    <div class="rounded-full bg-slate-200 px-3 py-4">
+      <Share />
+    </div>
+  </div>
+
+  <div class="flex flex-col gap-y-2 rounded-3xl bg-white p-4">
+    <div class="flex flex-wrap gap-1">
+      <Badge variant="purple">Special Educational Needs</Badge>
+    </div>
+
+    <div class="flex flex-col gap-y-6">
+      <div class="flex flex-col gap-y-3">
+        <span class="text-xl font-medium text-slate-950">
+          Navigating Special Educational Needs: A Path to Inclusion
+        </span>
+
+        <div class="flex gap-x-1">
+          <span class="text-sm text-slate-600">By Guidance Branch</span>
+          <span class="text-sm text-slate-600">•</span>
+          <span class="text-sm text-slate-600">2 days ago</span>
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-y-4">
+        <button
+          class="py-2.75 flex cursor-pointer items-center justify-center gap-x-1 rounded-full border border-transparent bg-slate-950 px-4 text-white transition-colors hover:bg-slate-900/90 disabled:pointer-events-none disabled:opacity-50"
+        >
+          <Play class="h-4 w-4" />
+          <span class="font-medium">Play</span>
+        </button>
+
+        <a
+          href="/content/1/quiz"
+          class="py-2.75 flex cursor-pointer items-center justify-center gap-x-1 rounded-full border border-slate-300 bg-white px-4 text-slate-950 transition-colors hover:bg-slate-100"
+        >
+          <Lightbulb class="h-4 w-4" />
+          <span class="font-medium">Take the quiz</span>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/apps/learner/src/routes/content/[id]/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/+page.svelte
@@ -13,9 +13,11 @@
       <ArrowLeft />
     </div>
 
-    <div class="rounded-full bg-slate-200 px-3 py-4">
+    <button
+      class="cursor-pointer rounded-full bg-slate-200 px-3 py-4 transition-colors hover:bg-slate-300"
+    >
       <Share />
-    </div>
+    </button>
   </div>
 
   <div class="flex flex-col gap-y-2 rounded-3xl bg-white p-4">

--- a/apps/learner/src/routes/content/[id]/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/+page.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import { ArrowLeft, Lightbulb, Play, Share } from '@lucide/svelte';
+  import { formatDistanceToNow } from 'date-fns';
 
   import Badge from '$lib/components/Badge.svelte';
+
+  const { data } = $props();
 </script>
 
 <div class="flex flex-col gap-y-6 p-6">
@@ -17,19 +20,23 @@
 
   <div class="flex flex-col gap-y-2 rounded-3xl bg-white p-4">
     <div class="flex flex-wrap gap-1">
-      <Badge variant="purple">Special Educational Needs</Badge>
+      {#each data.tags as tag (tag)}
+        <Badge variant="purple">{tag}</Badge>
+      {/each}
     </div>
 
     <div class="flex flex-col gap-y-6">
       <div class="flex flex-col gap-y-3">
         <span class="text-xl font-medium text-slate-950">
-          Navigating Special Educational Needs: A Path to Inclusion
+          {data.title}
         </span>
 
         <div class="flex gap-x-1">
           <span class="text-sm text-slate-600">By Guidance Branch</span>
           <span class="text-sm text-slate-600">•</span>
-          <span class="text-sm text-slate-600">2 days ago</span>
+          <span class="text-sm text-slate-600">
+            {formatDistanceToNow(data.createdAt, { addSuffix: true })}
+          </span>
         </div>
       </div>
 
@@ -42,7 +49,7 @@
         </button>
 
         <a
-          href="/content/1/quiz"
+          href={`/content/${data.id}/quiz`}
           class="py-2.75 flex cursor-pointer items-center justify-center gap-x-1 rounded-full border border-slate-300 bg-white px-4 text-slate-950 transition-colors hover:bg-slate-100"
         >
           <Lightbulb class="h-4 w-4" />

--- a/apps/learner/src/routes/content/[id]/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/+page.svelte
@@ -2,16 +2,28 @@
   import { ArrowLeft, Lightbulb, Play, Share } from '@lucide/svelte';
   import { formatDistanceToNow } from 'date-fns';
 
+  import { afterNavigate } from '$app/navigation';
   import Badge from '$lib/components/Badge.svelte';
 
   const { data } = $props();
+
+  let returnTo = $state('/');
+
+  afterNavigate(({ from, type }) => {
+    if (type === 'enter' || !from) {
+      returnTo = '/';
+      return;
+    }
+
+    returnTo = from.url.pathname;
+  });
 </script>
 
 <div class="flex flex-col gap-y-6 p-6">
   <div class="flex justify-between">
-    <div class="rounded-full bg-slate-200 px-3 py-4">
+    <a href={returnTo} class="rounded-full bg-slate-200 px-3 py-4">
       <ArrowLeft />
-    </div>
+    </a>
 
     <button
       class="cursor-pointer rounded-full bg-slate-200 px-3 py-4 transition-colors hover:bg-slate-300"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.11
         version: 4.1.11(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       svelte:
         specifier: ^5.34.9
         version: 5.34.9
@@ -1017,6 +1020,9 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
@@ -2762,6 +2768,8 @@ snapshots:
       which: 2.0.2
 
   cssesc@3.0.0: {}
+
+  date-fns@4.1.0: {}
 
   debug@4.4.1:
     dependencies:


### PR DESCRIPTION
Closes #59 

## 🚀 Summary

This PR introduces a new Learning Unit page. It sets up the structure for retrieving and displaying learning unit data, currently using hardcoded data as a placeholder. Future work will connect this page to the database. For now, the tags of a learning unit are always displayed in purple. Future work will map each tag to a specific color, either on the client or server side.

## ✏️ Changes

- Added a new Learning Unit page to the learner app
- Implemented server-side retrieval of learning unit data using hardcoded data