### PR TITLE
feat(learner): add Progress component

### DIFF
--- a/apps/learner/src/lib/components/Progress.svelte
+++ b/apps/learner/src/lib/components/Progress.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  interface Props extends HTMLAttributes<HTMLDivElement> {
+    /**
+     * The progress value, between 0 and 100.
+     * Defaults to 0 if not provided.
+     */
+    value?: number;
+  }
+
+  const { value = 0, ...otherProps }: Props = $props();
+</script>
+
+<div {...otherProps} class="relative h-3 w-full overflow-hidden rounded-full bg-white">
+  <div
+    class="h-full w-full flex-1 bg-slate-900 transition-all"
+    style="transform: translateX(-{100 - value}%)"
+  ></div>
+</div>

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -2,6 +2,7 @@
   import { ArrowLeft } from '@lucide/svelte';
 
   import { page } from '$app/state';
+  import Progress from '$lib/components/Progress.svelte';
 
   const { data } = $props();
 
@@ -9,6 +10,10 @@
   let currentQuestionIndex = $state(0);
 
   let currentQuestion = $derived(data.questionAnswers[currentQuestionIndex]);
+
+  let percentageCompleted = $derived(
+    ((currentQuestionIndex + 1) / data.questionAnswers.length) * 100,
+  );
 
   const contentId = $derived(page.params.id);
 
@@ -35,10 +40,11 @@
 
 <main class="mx-auto flex h-full w-full max-w-5xl flex-col">
   <div class="flex h-full flex-col gap-y-6 p-6">
-    <div class="flex items-center">
+    <div class="flex items-center gap-x-8">
       <a class="rounded-full bg-slate-200 px-3 py-4" href="/content/{contentId}">
         <ArrowLeft />
       </a>
+      <Progress value={percentageCompleted} />
     </div>
 
     <div class="flex flex-1 flex-col gap-y-6">

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -45,6 +45,7 @@
         <ArrowLeft />
       </a>
       <Progress value={percentageCompleted} />
+      <span class="text-sm">{currentQuestionIndex + 1}/{data.questionAnswers.length}</span>
     </div>
 
     <div class="flex flex-1 flex-col gap-y-6">


### PR DESCRIPTION
Closes #50 

## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->
This PR introduces a new `Progress` component to the learner app. The component is designed mainly to support tracking the progress of the quiz

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->
- Created new `Progress` component
- Added `Progress` component to quiz page
- Also made a minor change to add text progress for quiz to go in line with how figma displays

## 📝 Notes
Currently `Progress` is built in a lightweight manner to only support quiz for now. But in future this should also be allowed to extend to be used for a new `Slider` component that is to be used for the podcast player