### PR TITLE
feat(learner): add collapsible summary section to learning unit page

### DIFF
--- a/apps/learner/src/routes/content/[id]/+page.server.ts
+++ b/apps/learner/src/routes/content/[id]/+page.server.ts
@@ -3,8 +3,10 @@ import type { PageServerLoad } from './$types';
 export const load: PageServerLoad = async () => {
   return {
     id: 1,
-    title: 'Navigating Special Educational Needs: A Path to Inclusion',
     tags: ['Special Educational Needs'],
+    title: 'Navigating Special Educational Needs: A Path to Inclusion',
+    summary:
+      "This podcast explores how teachers in Singapore can effectively support students with Special Educational Needs (SEN) in mainstream classrooms, fostering inclusion through practical strategies and collaboration. Learn key approaches to address diverse learning needs, align with MOE's inclusive education goals, and create equitable learning environments.",
     createdAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
   };
 };

--- a/apps/learner/src/routes/content/[id]/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ArrowLeft, Lightbulb, Play, Share } from '@lucide/svelte';
+  import { ArrowLeft, ChevronsDown, Lightbulb, Play, Share } from '@lucide/svelte';
   import { formatDistanceToNow } from 'date-fns';
 
   import { afterNavigate } from '$app/navigation';
@@ -9,6 +9,7 @@
   const { data } = $props();
 
   let returnTo = $state('/');
+  let expanded = $state(false);
 
   afterNavigate(({ from, type }) => {
     if (type === 'enter' || !from) {
@@ -18,6 +19,10 @@
 
     returnTo = from.url.pathname;
   });
+
+  const toggleExpanded = () => {
+    expanded = !expanded;
+  };
 </script>
 
 <div class="flex flex-col gap-y-6 p-6">
@@ -33,39 +38,61 @@
     </button>
   </div>
 
-  <div class="flex flex-col gap-y-2 rounded-3xl bg-white p-4">
-    <div class="flex flex-wrap gap-1">
-      {#each data.tags as tag (tag)}
-        <Badge variant="purple">{tag}</Badge>
-      {/each}
-    </div>
+  <div class="flex flex-col gap-y-6">
+    <div class="flex flex-col gap-y-2 rounded-3xl bg-white p-4">
+      <div class="flex flex-wrap gap-1">
+        {#each data.tags as tag (tag)}
+          <Badge variant="purple">{tag}</Badge>
+        {/each}
+      </div>
 
-    <div class="flex flex-col gap-y-6">
-      <div class="flex flex-col gap-y-3">
-        <span class="text-xl font-medium text-slate-950">
-          {data.title}
-        </span>
-
-        <div class="flex gap-x-1">
-          <span class="text-sm text-slate-600">By Guidance Branch</span>
-          <span class="text-sm text-slate-600">•</span>
-          <span class="text-sm text-slate-600">
-            {formatDistanceToNow(data.createdAt, { addSuffix: true })}
+      <div class="flex flex-col gap-y-6">
+        <div class="flex flex-col gap-y-3">
+          <span class="text-xl font-medium text-slate-950">
+            {data.title}
           </span>
+
+          <div class="flex gap-x-1">
+            <span class="text-sm text-slate-600">By Guidance Branch</span>
+            <span class="text-sm text-slate-600">•</span>
+            <span class="text-sm text-slate-600">
+              {formatDistanceToNow(data.createdAt, { addSuffix: true })}
+            </span>
+          </div>
+        </div>
+
+        <div class="flex flex-col gap-y-4">
+          <Button size="md">
+            <Play class="h-4 w-4" />
+            <span class="font-medium">Play</span>
+          </Button>
+
+          <Button href={`/content/${data.id}/quiz`} variant="secondary" size="md">
+            <Lightbulb class="h-4 w-4" />
+            <span class="font-medium">Take the quiz</span>
+          </Button>
         </div>
       </div>
+    </div>
 
-      <div class="flex flex-col gap-y-4">
-        <Button size="md">
-          <Play class="h-4 w-4" />
-          <span class="font-medium">Play</span>
-        </Button>
-
-        <Button href={`/content/${data.id}/quiz`} variant="secondary" size="md">
-          <Lightbulb class="h-4 w-4" />
-          <span class="font-medium">Take the quiz</span>
-        </Button>
+    <div class="flex flex-col gap-y-1">
+      <div
+        class={[
+          'mask-b-from-10% max-h-20 overflow-hidden',
+          expanded && 'mask-b-from-100% max-h-full',
+        ]}
+      >
+        <p class={['line-clamp-4 text-sm', expanded && 'line-clamp-none']}>
+          {data.summary}
+        </p>
       </div>
+
+      {#if !expanded}
+        <button class="flex w-fit cursor-pointer items-center gap-x-1" onclick={toggleExpanded}>
+          <span class="text-sm font-medium">Read more</span>
+          <ChevronsDown class="h-4 w-4" />
+        </button>
+      {/if}
     </div>
   </div>
 </div>


### PR DESCRIPTION
Closes #60

## 🚀 Summary

This PR adds a collapsible summary section to the learning unit page in the learner app.

## ✏️ Changes

- Added a collapsible summary section to the learning unit page (`src/routes/content/[id]/+page.svelte`)
- Enhanced server-side data structure with summary field (`src/routes/content/[id]/+page.server.ts`)
- Applied CSS masking and line clamping for elegant text truncation
- Restructured UI layout to accommodate the new summary section

## 📝 Notes

No transition/animation is added when expanding the summary section.