### PR TITLE
feat(learner): update layout across all pages except the quiz page

### DIFF
--- a/apps/learner/src/app.html
+++ b/apps/learner/src/app.html
@@ -1,12 +1,15 @@
 <!doctype html>
-<html lang="en" class="h-dvh">
+<html lang="en" class="h-full">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="%sveltekit.assets%/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     %sveltekit.head%
   </head>
-  <body data-sveltekit-preload-data="hover" class="font-geist h-full bg-slate-100 text-slate-950">
+  <body
+    data-sveltekit-preload-data="hover"
+    class="font-geist flex min-h-full bg-slate-100 text-slate-950"
+  >
     <div class="contents">%sveltekit.body%</div>
   </body>
 </html>

--- a/apps/learner/src/lib/components/Collection.svelte
+++ b/apps/learner/src/lib/components/Collection.svelte
@@ -36,7 +36,7 @@
 <a
   href={to}
   class={[
-    'flex flex-col gap-y-2 rounded-3xl bg-gradient-to-b p-6',
+    'shadow-xs flex flex-col gap-y-2 rounded-3xl bg-gradient-to-b p-6',
     variant === 'purple' && 'from-purple-800 via-purple-500 to-fuchsia-500',
     variant === 'amber' && 'from-amber-400 to-yellow-300',
     variant === 'teal' && 'from-teal-400 to-blue-500',

--- a/apps/learner/src/lib/components/LearningUnit.svelte
+++ b/apps/learner/src/lib/components/LearningUnit.svelte
@@ -37,7 +37,7 @@
   };
 </script>
 
-<a href={to} class="flex flex-col gap-y-6 rounded-3xl bg-white p-6">
+<a href={to} class="shadow-xs flex flex-col gap-y-6 rounded-3xl bg-white p-6">
   <div class="flex flex-col gap-y-2">
     <div class="flex flex-wrap gap-1">
       {#each tags as tag (tag.content)}

--- a/apps/learner/src/lib/components/LearningUnit.svelte
+++ b/apps/learner/src/lib/components/LearningUnit.svelte
@@ -61,7 +61,7 @@
   {#if showplayerpanel}
     <div class="flex items-center gap-x-3">
       <button
-        class="flex cursor-pointer items-center gap-x-2 rounded-full bg-slate-100 px-6 py-4"
+        class="flex cursor-pointer items-center gap-x-2 rounded-full bg-slate-100 px-6 py-4 transition-colors hover:bg-slate-200"
         onclick={handlePlay}
       >
         <Play />

--- a/apps/learner/src/routes/(app)/+layout.svelte
+++ b/apps/learner/src/routes/(app)/+layout.svelte
@@ -17,7 +17,6 @@
   onMount(() => {
     const observer = new IntersectionObserver(([entry]) => {
       isWithinViewport = entry.isIntersecting;
-      console.log(isWithinViewport);
     });
 
     if (target) {

--- a/apps/learner/src/routes/(app)/+layout.svelte
+++ b/apps/learner/src/routes/(app)/+layout.svelte
@@ -40,7 +40,7 @@
   ></div>
 
   <div class="mx-auto w-full max-w-5xl px-4 py-3">
-    <div class="flex flex-col gap-y-3">
+    <div class="flex flex-col gap-y-4">
       <div class="flex items-center justify-between px-2">
         <span class="text-2xl font-semibold">Onward</span>
         <div class="h-10 w-10 rounded-full bg-white"></div>
@@ -117,7 +117,7 @@
   </div>
 </header>
 
-<main class="pt-42 relative mx-auto min-h-full w-full max-w-5xl px-4 pb-3">
+<main class="pt-43 relative mx-auto min-h-full w-full max-w-5xl px-4 pb-3">
   <div bind:this={target} class="absolute inset-x-0 top-0 h-px"></div>
 
   {@render children()}

--- a/apps/learner/src/routes/(app)/+layout.svelte
+++ b/apps/learner/src/routes/(app)/+layout.svelte
@@ -41,7 +41,7 @@
 
   <div class="mx-auto w-full max-w-5xl px-4 py-3">
     <div class="flex flex-col gap-y-3">
-      <div class="flex items-center justify-between">
+      <div class="flex items-center justify-between px-2">
         <span class="text-2xl font-semibold">Onward</span>
         <div class="h-10 w-10 rounded-full bg-white"></div>
       </div>

--- a/apps/learner/src/routes/(app)/+layout.svelte
+++ b/apps/learner/src/routes/(app)/+layout.svelte
@@ -1,93 +1,125 @@
 <script lang="ts">
   import { BookHeart, Compass, Home } from '@lucide/svelte';
+  import { onMount } from 'svelte';
 
   import { page } from '$app/state';
 
   const { children } = $props();
 
+  let isWithinViewport = $state(false);
+
   const isHomePage = $derived(page.url.pathname === '/');
   const isLearningPage = $derived(page.url.pathname === '/learning');
   const isExplorePage = $derived(page.url.pathname === '/explore');
+
+  let target: HTMLElement | null;
+
+  onMount(() => {
+    const observer = new IntersectionObserver(([entry]) => {
+      isWithinViewport = entry.isIntersecting;
+      console.log(isWithinViewport);
+    });
+
+    if (target) {
+      observer.observe(target);
+    }
+
+    return () => {
+      if (target) {
+        observer.unobserve(target);
+      }
+    };
+  });
 </script>
 
-<nav class="z-1000 sticky px-6 py-5">
-  <div class="flex flex-col gap-y-3">
-    <div class="flex items-center justify-between">
-      <span class="text-2xl font-semibold">Onward</span>
-      <div class="h-10 w-10 rounded-full bg-white"></div>
-    </div>
+<header class="fixed inset-x-0 top-0 z-50 bg-slate-100/90 backdrop-blur-sm">
+  <div
+    class={[
+      'absolute inset-x-0 top-full h-px bg-transparent transition-colors duration-300',
+      !isWithinViewport && '!bg-slate-950/7.5',
+    ]}
+  ></div>
 
-    <div class="flex items-center rounded-[80px] bg-white px-4">
-      <!-- Home -->
-      <a
-        href="/"
-        class="group flex flex-1 cursor-pointer flex-col items-center justify-center gap-y-1 pb-4 pt-3"
-      >
-        <div
-          class={[
-            'rounded-[100px] px-5 py-1 transition-colors',
-            isHomePage && 'bg-slate-950 text-white',
-          ]}
-        >
-          <Home />
-        </div>
-        <span
-          class={[
-            'text-center text-xs font-semibold',
-            isHomePage ? 'text-slate-950' : 'text-slate-700',
-          ]}
-        >
-          Home
-        </span>
-      </a>
+  <div class="mx-auto w-full max-w-5xl px-4 py-3">
+    <div class="flex flex-col gap-y-3">
+      <div class="flex items-center justify-between">
+        <span class="text-2xl font-semibold">Onward</span>
+        <div class="h-10 w-10 rounded-full bg-white"></div>
+      </div>
 
-      <!-- Learning -->
-      <a
-        href="/learning"
-        class="group flex flex-1 cursor-pointer flex-col items-center justify-center gap-y-1 pb-4 pt-3"
-      >
-        <div
-          class={[
-            'rounded-[100px] px-5 py-1 transition-colors',
-            isLearningPage && 'bg-slate-950 text-white',
-          ]}
+      <div class="shadow-xs flex items-center rounded-[80px] bg-white px-4">
+        <a
+          href="/"
+          class="group flex flex-1 cursor-pointer flex-col items-center justify-center gap-y-1 pb-4 pt-3"
         >
-          <BookHeart />
-        </div>
-        <span
-          class={[
-            'text-center text-xs font-semibold',
-            isLearningPage ? 'text-slate-950' : 'text-slate-700',
-          ]}
-        >
-          Learning
-        </span>
-      </a>
+          <div
+            class={[
+              'rounded-[100px] px-5 py-1 transition-colors',
+              isHomePage && 'bg-slate-950 text-white',
+            ]}
+          >
+            <Home />
+          </div>
+          <span
+            class={[
+              'text-center text-xs font-semibold',
+              isHomePage ? 'text-slate-950' : 'text-slate-700',
+            ]}
+          >
+            Home
+          </span>
+        </a>
 
-      <!-- Explore -->
-      <a
-        href="/explore"
-        class="group flex flex-1 cursor-pointer flex-col items-center justify-center gap-y-1 pb-4 pt-3"
-      >
-        <div
-          class={[
-            'rounded-[100px] px-5 py-1 transition-colors',
-            isExplorePage && 'bg-slate-950 text-white',
-          ]}
+        <a
+          href="/learning"
+          class="group flex flex-1 cursor-pointer flex-col items-center justify-center gap-y-1 pb-4 pt-3"
         >
-          <Compass />
-        </div>
-        <span
-          class={[
-            'text-center text-xs font-semibold',
-            isExplorePage ? 'text-slate-950' : 'text-slate-700',
-          ]}
+          <div
+            class={[
+              'rounded-[100px] px-5 py-1 transition-colors',
+              isLearningPage && 'bg-slate-950 text-white',
+            ]}
+          >
+            <BookHeart />
+          </div>
+          <span
+            class={[
+              'text-center text-xs font-semibold',
+              isLearningPage ? 'text-slate-950' : 'text-slate-700',
+            ]}
+          >
+            Learning
+          </span>
+        </a>
+
+        <a
+          href="/explore"
+          class="group flex flex-1 cursor-pointer flex-col items-center justify-center gap-y-1 pb-4 pt-3"
         >
-          Explore
-        </span>
-      </a>
+          <div
+            class={[
+              'rounded-[100px] px-5 py-1 transition-colors',
+              isExplorePage && 'bg-slate-950 text-white',
+            ]}
+          >
+            <Compass />
+          </div>
+          <span
+            class={[
+              'text-center text-xs font-semibold',
+              isExplorePage ? 'text-slate-950' : 'text-slate-700',
+            ]}
+          >
+            Explore
+          </span>
+        </a>
+      </div>
     </div>
   </div>
-</nav>
+</header>
 
-{@render children()}
+<main class="pt-42 relative mx-auto min-h-full w-full max-w-5xl px-4 pb-3">
+  <div bind:this={target} class="absolute inset-x-0 top-0 h-px"></div>
+
+  {@render children()}
+</main>

--- a/apps/learner/src/routes/(app)/+page.svelte
+++ b/apps/learner/src/routes/(app)/+page.svelte
@@ -1,12 +1,25 @@
-<script>
+<script lang="ts">
   import LearningUnit from '$lib/components/LearningUnit.svelte';
 </script>
 
-<div class="px-6">
-  <LearningUnit
-    to="/content/1"
-    tags={[{ variant: 'purple', content: 'Special Educational Needs' }]}
-    title="Navigating Special Educational Needs in Singapore: A Path to Inclusion"
-    showplayerpanel
-  />
+<div class="flex flex-col gap-y-3">
+  <div class="px-2">
+    <span class="text-xl font-semibold">Recently learned</span>
+  </div>
+
+  <div class="flex flex-col gap-y-4">
+    <LearningUnit
+      to="/content/1"
+      tags={[{ variant: 'purple', content: 'Special Educational Needs' }]}
+      title="Navigating Special Educational Needs in Singapore: A Path to Inclusion"
+      showplayerpanel
+    />
+
+    <LearningUnit
+      to="/content/1"
+      tags={[{ variant: 'purple', content: 'Special Educational Needs' }]}
+      title="Navigating Special Educational Needs in Singapore: A Path to Inclusion"
+      showplayerpanel
+    />
+  </div>
 </div>

--- a/apps/learner/src/routes/(app)/explore/+page.svelte
+++ b/apps/learner/src/routes/(app)/explore/+page.svelte
@@ -1,1 +1,1 @@
-<div class="px-6">Explore page!</div>
+<div class="px-2">Explore page!</div>

--- a/apps/learner/src/routes/(app)/learning/+page.svelte
+++ b/apps/learner/src/routes/(app)/learning/+page.svelte
@@ -4,10 +4,12 @@
   const { data } = $props();
 </script>
 
-<div class="flex flex-col gap-y-6 overflow-y-auto p-6">
-  <span class="text-xl font-semibold">Your learnings</span>
+<div class="flex flex-col gap-y-3">
+  <div class="px-2">
+    <span class="text-xl font-semibold">Your learnings</span>
+  </div>
 
-  <div class="flex flex-col gap-4">
+  <div class="flex flex-col gap-y-3">
     {#each data.learningJourneys as learning (learning.id)}
       <Collection
         to={learning.to}

--- a/apps/learner/src/routes/+error.svelte
+++ b/apps/learner/src/routes/+error.svelte
@@ -4,15 +4,20 @@
   const is404 = page.status === 404;
 </script>
 
-<div class="flex h-full flex-col items-center justify-center gap-y-4 px-6 py-5">
-  <div class="flex flex-col items-center gap-y-1">
-    <h1 class="text-3xl font-bold">
-      {is404 ? 'Page not found' : 'Something went wrong'}
-    </h1>
-    <p class="text-sm text-slate-500">
-      {is404 ? 'The page you are looking for does not exist.' : 'Please try again later.'}
-    </p>
-  </div>
+<main class="relative mx-auto min-h-full w-full max-w-5xl px-4 py-3">
+  <div class="flex h-full flex-col items-center justify-center gap-y-4">
+    <div class="flex flex-col items-center gap-y-1">
+      <h1 class="text-center text-3xl font-bold">
+        {is404 ? 'Page not found' : 'Something went wrong'}
+      </h1>
 
-  <a href="/" class="rounded-full bg-slate-950 px-4 py-3 text-sm text-white">Go to Home</a>
-</div>
+      <p class="text-center text-sm text-slate-500">
+        {is404 ? 'The page you are looking for does not exist.' : 'Please try again later.'}
+      </p>
+    </div>
+
+    <a href="/" class="rounded-full bg-slate-950 px-4 py-3 text-center text-sm text-white">
+      Go to Home
+    </a>
+  </div>
+</main>

--- a/apps/learner/src/routes/+layout.svelte
+++ b/apps/learner/src/routes/+layout.svelte
@@ -4,6 +4,4 @@
   const { children } = $props();
 </script>
 
-<main class="mx-auto flex h-full w-full max-w-5xl flex-col">
-  {@render children()}
-</main>
+{@render children()}

--- a/apps/learner/src/routes/collection/[id]/+page.svelte
+++ b/apps/learner/src/routes/collection/[id]/+page.svelte
@@ -1,54 +1,99 @@
-<script>
+<script lang="ts">
   import { ArrowLeft } from '@lucide/svelte';
+  import { onMount } from 'svelte';
 
   import LearningUnit from '$lib/components/LearningUnit.svelte';
+
+  let isWithinViewport = $state(false);
+
+  let target: HTMLElement | null;
+
+  onMount(() => {
+    const observer = new IntersectionObserver(([entry]) => {
+      isWithinViewport = entry.isIntersecting;
+      console.log(isWithinViewport);
+    });
+
+    if (target) {
+      observer.observe(target);
+    }
+
+    return () => {
+      if (target) {
+        observer.unobserve(target);
+      }
+    };
+  });
 </script>
 
-<div class="flex flex-col gap-y-4 p-6">
-  <div class="flex items-center gap-x-3">
-    <a class="rounded-full bg-slate-200 px-3 py-4" href="/learning">
-      <ArrowLeft />
-    </a>
-    <span class="text-xl font-medium">SEN peer support</span>
+<header class="fixed inset-x-0 top-0 z-50 bg-slate-100/90 backdrop-blur-sm">
+  <div
+    class={[
+      'absolute inset-x-0 top-full h-px bg-transparent transition-colors duration-300',
+      !isWithinViewport && '!bg-slate-950/7.5',
+    ]}
+  ></div>
+
+  <div class="mx-auto w-full max-w-5xl px-4 py-3">
+    <div class="flex items-center justify-between gap-x-8">
+      <div class="flex items-center gap-x-3">
+        <a href="/learning" class="rounded-full px-3 py-4 transition-colors hover:bg-slate-200">
+          <ArrowLeft />
+        </a>
+
+        <span class="text-xl font-medium">SEN peer support</span>
+      </div>
+    </div>
   </div>
+</header>
 
-  <div class="flex flex-col gap-y-2 rounded-3xl bg-slate-200 p-4">
-    <span class="font-semibold text-black">About this topic</span>
-    <span class="text-black">
-      Explore the world of Special Educational Needs (SEN) peer support that indicates Singapore
-      specific peer support knowledges, case studies and more to gain knowledge about SEN. This
-      topic encompasses a variety of bite-sized.
-    </span>
+<main class="pt-23 relative mx-auto min-h-full w-full max-w-5xl px-4 pb-3">
+  <div bind:this={target} class="absolute inset-x-0 top-0 h-px"></div>
+
+  <div class="flex flex-col gap-y-6">
+    <div class="shadow-xs flex flex-col gap-y-2 rounded-3xl bg-slate-200 p-4">
+      <span class="text-lg font-medium">About this topic</span>
+
+      <span>
+        Explore the world of Special Educational Needs (SEN) peer support that indicates Singapore
+        specific peer support knowledges, case studies and more to gain knowledge about SEN. This
+        topic encompasses a variety of bite-sized.
+      </span>
+    </div>
+
+    <div class="flex flex-col gap-y-3">
+      <div class="px-2">
+        <span class="text-xl font-semibold">12 podcasts</span>
+      </div>
+
+      <div class="flex flex-col gap-y-4">
+        <LearningUnit
+          to="/content/1"
+          tags={[
+            { variant: 'purple', content: 'Special Educational Needs' },
+            { variant: 'slate', content: 'Podcast' },
+          ]}
+          title="Navigating Special Educational Needs in Singapore: A Path to Inclusion"
+        />
+
+        <LearningUnit
+          to="/content/1"
+          tags={[
+            { variant: 'purple', content: 'Special Educational Needs' },
+            { variant: 'slate', content: 'Podcast' },
+          ]}
+          title="Navigating Special Educational Needs in Singapore: A Path to Inclusion"
+        />
+
+        <LearningUnit
+          to="/content/1"
+          tags={[
+            { variant: 'purple', content: 'Special Educational Needs' },
+            { variant: 'slate', content: 'Podcast' },
+          ]}
+          title="Navigating Special Educational Needs in Singapore: A Path to Inclusion"
+        />
+      </div>
+    </div>
   </div>
-
-  <div class="flex flex-col gap-y-3">
-    <span class="text-xl font-medium">12 podcasts</span>
-
-    <LearningUnit
-      to="/content/1"
-      tags={[
-        { variant: 'purple', content: 'Special Educational Needs' },
-        { variant: 'slate', content: 'Podcast' },
-      ]}
-      title="Navigating Special Educational Needs in Singapore: A Path to Inclusion"
-    />
-
-    <LearningUnit
-      to="/content/1"
-      tags={[
-        { variant: 'purple', content: 'Special Educational Needs' },
-        { variant: 'slate', content: 'Podcast' },
-      ]}
-      title="Navigating Special Educational Needs in Singapore: A Path to Inclusion"
-    />
-
-    <LearningUnit
-      to="/content/1"
-      tags={[
-        { variant: 'purple', content: 'Special Educational Needs' },
-        { variant: 'slate', content: 'Podcast' },
-      ]}
-      title="Navigating Special Educational Needs in Singapore: A Path to Inclusion"
-    />
-  </div>
-</div>
+</main>

--- a/apps/learner/src/routes/collection/[id]/+page.svelte
+++ b/apps/learner/src/routes/collection/[id]/+page.svelte
@@ -11,7 +11,6 @@
   onMount(() => {
     const observer = new IntersectionObserver(([entry]) => {
       isWithinViewport = entry.isIntersecting;
-      console.log(isWithinViewport);
     });
 
     if (target) {

--- a/apps/learner/src/routes/content/[id]/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/+page.svelte
@@ -27,7 +27,6 @@
   onMount(() => {
     const observer = new IntersectionObserver(([entry]) => {
       isWithinViewport = entry.isIntersecting;
-      console.log(isWithinViewport);
     });
 
     if (target) {

--- a/apps/learner/src/routes/content/[id]/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { ArrowLeft, ChevronsDown, Lightbulb, Play, Share } from '@lucide/svelte';
   import { formatDistanceToNow } from 'date-fns';
+  import { onMount } from 'svelte';
 
   import { afterNavigate } from '$app/navigation';
   import Badge from '$lib/components/Badge.svelte';
@@ -9,7 +10,10 @@
   const { data } = $props();
 
   let returnTo = $state('/');
+  let isWithinViewport = $state(false);
   let isExpanded = $state(false);
+
+  let target: HTMLElement | null;
 
   afterNavigate(({ from, type }) => {
     if (type === 'enter' || !from) {
@@ -20,26 +24,54 @@
     returnTo = from.url.pathname;
   });
 
+  onMount(() => {
+    const observer = new IntersectionObserver(([entry]) => {
+      isWithinViewport = entry.isIntersecting;
+      console.log(isWithinViewport);
+    });
+
+    if (target) {
+      observer.observe(target);
+    }
+
+    return () => {
+      if (target) {
+        observer.unobserve(target);
+      }
+    };
+  });
+
   const toggleIsExpanded = () => {
     isExpanded = !isExpanded;
   };
 </script>
 
-<div class="flex flex-col gap-y-6 p-6">
-  <div class="flex justify-between">
-    <a href={returnTo} class="rounded-full bg-slate-200 px-3 py-4">
-      <ArrowLeft />
-    </a>
+<header class="fixed inset-x-0 top-0 z-50 bg-slate-100/90 backdrop-blur-sm">
+  <div
+    class={[
+      'absolute inset-x-0 top-full h-px bg-transparent transition-colors duration-300',
+      !isWithinViewport && '!bg-slate-950/7.5',
+    ]}
+  ></div>
 
-    <button
-      class="cursor-pointer rounded-full bg-slate-200 px-3 py-4 transition-colors hover:bg-slate-300"
-    >
-      <Share />
-    </button>
+  <div class="mx-auto w-full max-w-5xl px-4 py-3">
+    <div class="flex items-center justify-between gap-x-8">
+      <a href={returnTo} class="rounded-full px-3 py-4 transition-colors hover:bg-slate-200">
+        <ArrowLeft />
+      </a>
+
+      <button class="cursor-pointer rounded-full px-3 py-4 transition-colors hover:bg-slate-200">
+        <Share />
+      </button>
+    </div>
   </div>
+</header>
+
+<main class="pt-23 relative mx-auto min-h-full w-full max-w-5xl px-4 pb-3">
+  <div bind:this={target} class="absolute inset-x-0 top-0 h-px"></div>
 
   <div class="flex flex-col gap-y-6">
-    <div class="flex flex-col gap-y-2 rounded-3xl bg-white p-4">
+    <div class="shadow-xs flex flex-col gap-y-2 rounded-3xl bg-white p-4">
       <div class="flex flex-wrap gap-1">
         {#each data.tags as tag (tag)}
           <Badge variant="purple">{tag}</Badge>
@@ -75,24 +107,27 @@
       </div>
     </div>
 
-    <div class="flex flex-col gap-y-1">
+    <div class="flex flex-col items-center gap-y-4">
       <div
         class={[
-          'mask-b-from-10% max-h-20 overflow-hidden',
+          'mask-b-from-10% max-h-28 overflow-hidden',
           isExpanded && 'mask-b-from-100% max-h-full',
         ]}
       >
-        <p class={['line-clamp-4 text-sm', isExpanded && 'line-clamp-none']}>
+        <p class={['line-clamp-4 text-lg', isExpanded && 'line-clamp-none']}>
           {data.summary}
         </p>
       </div>
 
       {#if !isExpanded}
-        <button class="flex w-fit cursor-pointer items-center gap-x-1" onclick={toggleIsExpanded}>
+        <button
+          class="flex w-fit cursor-pointer items-center gap-x-1 px-4 py-2"
+          onclick={toggleIsExpanded}
+        >
           <span class="text-sm font-medium">Read more</span>
           <ChevronsDown class="h-4 w-4" />
         </button>
       {/if}
     </div>
   </div>
-</div>
+</main>

--- a/apps/learner/src/routes/content/[id]/quiz/+layout.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+layout.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  const { children } = $props();
+</script>
+
+<!-- Temporary layout for the quiz page -->
+<main class="mx-auto flex h-full w-full max-w-5xl flex-col">
+  {@render children()}
+</main>

--- a/apps/learner/src/routes/profile/+page.svelte
+++ b/apps/learner/src/routes/profile/+page.svelte
@@ -1,1 +1,1 @@
-<div class="px-6 py-5">Profile page!</div>
+<div class="px-2">Profile page!</div>


### PR DESCRIPTION
## 🚀 Summary

This PR standardises the layout across all learner pages by implementing a consistent `header` and `main` element structure. The `header` element contains navigation functionality and CTAs that remain visible throughout scrolling, while the `main` element contains the primary content. Page padding has been optimised for mobile screens (`16px` horizontal, `12px` vertical) to provide more content space. This improves the overall user experience and visual consistency throughout the application.

## ✏️ Changes

- Standardised layout structure with `header` and `main` elements across all learner pages
- Adjusted page padding from 24px all sides to 16px horizontal and 12px vertical for better mobile content space
- Added dynamic bottom border/separator that appears when scrolling downwards
- Enhanced visual depth by adding shadows to `Collection` and `LearningUnit` components
- Improved user interaction feedback with hover effects on play buttons in `LearningUnit` component

## 📝 Notes

- The quiz page is intentionally excluded from these changes as it's still under development.
- There are multiple repeated dynamic bottom border/separator logic across the pages, it will be consolidated in reusable components once it is stable.
- Page padding may be adjusted again once main features are complete and UI discrepancies with UX designs are addressed.