### PR TITLE
feat(learner): add floating podcast player

### DIFF
--- a/apps/learner/src/lib/components/FloatingPlayer.svelte
+++ b/apps/learner/src/lib/components/FloatingPlayer.svelte
@@ -31,29 +31,26 @@
   };
 </script>
 
-<a
-  href={to}
-  class="inset-shadow-sm z-100 fixed bottom-6 left-6 right-6 rounded-full bg-white/90 p-3 shadow-lg backdrop-blur-sm"
->
-  <div class="flex items-center gap-x-3">
-    <!-- Temporary album placeholder -->
-    <div class="h-12 w-12 rounded-full bg-black"></div>
+<div class="z-100 fixed bottom-6 left-6 right-6 flex flex-col gap-4">
+  <a href={to} class="inset-shadow-sm rounded-full bg-white/90 p-3 shadow-lg backdrop-blur-sm">
+    <div class="flex items-center gap-x-3">
+      <!-- Temporary album placeholder -->
+      <div class="h-12 w-12 rounded-full bg-black"></div>
 
-    <div class="flex-1 truncate">
-      <span class="text-sm font-medium">
+      <div class="flex-1 truncate text-sm font-medium">
         {title}
-      </span>
-    </div>
+      </div>
 
-    <button
-      class="flex cursor-pointer items-center rounded-full px-4 py-2 hover:bg-slate-50"
-      onclick={handlePlay}
-    >
-      {#if isplaying}
-        <Pause />
-      {:else}
-        <Play />
-      {/if}
-    </button>
-  </div>
-</a>
+      <button
+        class="flex cursor-pointer items-center rounded-full px-4 py-2 hover:bg-slate-50"
+        onclick={handlePlay}
+      >
+        {#if isplaying}
+          <Pause />
+        {:else}
+          <Play />
+        {/if}
+      </button>
+    </div>
+  </a>
+</div>

--- a/apps/learner/src/lib/components/FloatingPlayer.svelte
+++ b/apps/learner/src/lib/components/FloatingPlayer.svelte
@@ -31,26 +31,27 @@
   };
 </script>
 
-<div class="z-100 fixed bottom-6 left-6 right-6 flex flex-col">
-  <a href={to} class="inset-shadow-sm rounded-full bg-white/90 p-3 shadow-lg backdrop-blur-sm">
-    <div class="flex items-center gap-x-3">
-      <!-- Temporary album placeholder -->
-      <div class="h-12 w-12 rounded-full bg-black"></div>
+<div class="z-100 fixed bottom-6 left-6 right-6">
+  <a
+    href={to}
+    class="inset-shadow-sm flex items-center gap-x-3 rounded-full bg-white/90 p-3 shadow-lg backdrop-blur-sm"
+  >
+    <!-- Temporary album placeholder -->
+    <div class="h-12 w-12 rounded-full bg-black"></div>
 
-      <div class="flex-1 truncate text-sm font-medium">
-        {title}
-      </div>
-
-      <button
-        class="flex cursor-pointer items-center rounded-full px-4 py-2 hover:bg-slate-50"
-        onclick={handlePlay}
-      >
-        {#if isplaying}
-          <Pause />
-        {:else}
-          <Play />
-        {/if}
-      </button>
+    <div class="flex-1 truncate text-sm font-medium">
+      {title}
     </div>
+
+    <button
+      class="flex cursor-pointer items-center rounded-full px-4 py-2 hover:bg-slate-50"
+      onclick={handlePlay}
+    >
+      {#if isplaying}
+        <Pause />
+      {:else}
+        <Play />
+      {/if}
+    </button>
   </a>
 </div>

--- a/apps/learner/src/lib/components/FloatingPlayer.svelte
+++ b/apps/learner/src/lib/components/FloatingPlayer.svelte
@@ -31,7 +31,7 @@
   };
 </script>
 
-<div class="z-100 fixed bottom-6 left-6 right-6 flex flex-col gap-4">
+<div class="z-100 fixed bottom-6 left-6 right-6 flex flex-col">
   <a href={to} class="inset-shadow-sm rounded-full bg-white/90 p-3 shadow-lg backdrop-blur-sm">
     <div class="flex items-center gap-x-3">
       <!-- Temporary album placeholder -->

--- a/apps/learner/src/lib/components/FloatingPlayer.svelte
+++ b/apps/learner/src/lib/components/FloatingPlayer.svelte
@@ -40,7 +40,7 @@
     <div class="h-12 w-12 rounded-full bg-black"></div>
 
     <div class="flex-1 truncate">
-      <span class="text-sm font-medium text-black">
+      <span class="text-sm font-medium">
         {title}
       </span>
     </div>

--- a/apps/learner/src/lib/components/FloatingPlayer.svelte
+++ b/apps/learner/src/lib/components/FloatingPlayer.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  import { Pause, Play } from '@lucide/svelte';
+  import type { MouseEventHandler } from 'svelte/elements';
+
+  interface Props {
+    /**
+     * The URL to navigate to when the user clicks on the floating player.
+     */
+    to: string;
+    /**
+     * The title of the podcast.
+     */
+    title: string;
+    /**
+     * Indicates whether the player is in a playing or paused state.
+     */
+    isplaying?: boolean;
+    /**
+     * A callback function that is called when the user clicks on the play button.
+     */
+    onplay?: MouseEventHandler<HTMLButtonElement>;
+  }
+
+  let { to, title, isplaying = false, onplay }: Props = $props();
+
+  const handlePlay: MouseEventHandler<HTMLButtonElement> = (event) => {
+    // Prevent the default behavior of the anchor tag from navigating to the URL.
+    event.preventDefault();
+
+    onplay?.(event);
+  };
+</script>
+
+<a
+  href={to}
+  class="inset-shadow-sm z-100 fixed bottom-6 left-6 right-6 rounded-full bg-white/90 p-3 shadow-lg backdrop-blur-sm"
+>
+  <div class="flex items-center gap-x-3">
+    <!-- Temporary album placeholder -->
+    <div class="h-12 w-12 rounded-full bg-black"></div>
+
+    <div class="flex-1 truncate">
+      <span class="text-sm font-medium text-black">
+        {title}
+      </span>
+    </div>
+
+    <button
+      class="flex cursor-pointer items-center rounded-full px-4 py-2 hover:bg-slate-50"
+      onclick={handlePlay}
+    >
+      {#if isplaying}
+        <Pause />
+      {:else}
+        <Play />
+      {/if}
+    </button>
+  </div>
+</a>

--- a/apps/learner/src/routes/(app)/+page.svelte
+++ b/apps/learner/src/routes/(app)/+page.svelte
@@ -2,11 +2,11 @@
   import FloatingPlayer from '$lib/components/FloatingPlayer.svelte';
   import LearningUnit from '$lib/components/LearningUnit.svelte';
 
-  let isFloatingPodcastVisible = $state(false);
+  let isFloatingPlayerVisible = $state(false);
   let isPlaying = $state(false);
 
   function handlePlay() {
-    isFloatingPodcastVisible = true;
+    isFloatingPlayerVisible = true;
     isPlaying = true;
   }
 
@@ -37,7 +37,7 @@
       onplay={handlePlay}
     />
 
-    {#if isFloatingPodcastVisible}
+    {#if isFloatingPlayerVisible}
       <FloatingPlayer
         to="/"
         title="Navigating Special Educational Needs in Singapore: A Path to Inclusion"

--- a/apps/learner/src/routes/(app)/+page.svelte
+++ b/apps/learner/src/routes/(app)/+page.svelte
@@ -1,5 +1,18 @@
 <script lang="ts">
+  import FloatingPlayer from '$lib/components/FloatingPlayer.svelte';
   import LearningUnit from '$lib/components/LearningUnit.svelte';
+
+  let isFloatingPodcastVisible = $state(false);
+  let isPlaying = $state(false);
+
+  function handlePlay() {
+    isFloatingPodcastVisible = true;
+    isPlaying = true;
+  }
+
+  function togglePlayPause() {
+    isPlaying = !isPlaying;
+  }
 </script>
 
 <div class="flex flex-col gap-y-3">
@@ -13,6 +26,7 @@
       tags={[{ variant: 'purple', content: 'Special Educational Needs' }]}
       title="Navigating Special Educational Needs in Singapore: A Path to Inclusion"
       showplayerpanel
+      onplay={handlePlay}
     />
 
     <LearningUnit
@@ -20,6 +34,16 @@
       tags={[{ variant: 'purple', content: 'Special Educational Needs' }]}
       title="Navigating Special Educational Needs in Singapore: A Path to Inclusion"
       showplayerpanel
+      onplay={handlePlay}
     />
+
+    {#if isFloatingPodcastVisible}
+      <FloatingPlayer
+        to="/"
+        title="Navigating Special Educational Needs in Singapore: A Path to Inclusion"
+        isplaying={isPlaying}
+        onplay={togglePlayPause}
+      />
+    {/if}
   </div>
 </div>


### PR DESCRIPTION
Closes https://github.com/String-sg/onward/issues/62

## 🚀 Summary

This update introduces the `FloatingPlayer` component, which allows users to toggle between play and pause states for podcasts. It provides a simple and reusable design for managing playback functionality within the learner app.

## ✏️ Changes

- Implemented isplaying state to dynamically control playback.
- Added onplay callback to handle play/pause events.
- Created a reusable FloatingPlayer component with a modern UI.

##  📝 Note 

The functionality to ensure the floating player persists across page navigations will be addressed in a _future pull request._