### PR TITLE
feat(learner): Standardise quiz page layout

### DIFF
--- a/apps/learner/src/routes/content/[id]/quiz/+layout.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+layout.svelte
@@ -1,8 +1,0 @@
-<script lang="ts">
-  const { children } = $props();
-</script>
-
-<!-- Temporary layout for the quiz page -->
-<main class="mx-auto flex h-full w-full max-w-5xl flex-col">
-  {@render children()}
-</main>

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -149,7 +149,7 @@
           <span class="font-medium">Your answer</span>
           <div
             class={[
-              'gap-x-2.75 py-3.75 flex w-full items-center rounded-2xl border border-transparent bg-lime-200 px-3',
+              'py-3.75 px-2.75 flex w-full items-center gap-x-3 rounded-2xl border border-transparent bg-lime-200',
               selectedOptionIndex !== currentQuestion.answer - 1 && '!border-slate-950 !bg-white',
             ]}
           >
@@ -172,7 +172,7 @@
           <div class="flex flex-col gap-y-2">
             <span class="font-medium">Correct answer</span>
             <div
-              class="gap-x-2.75 py-3.75 flex w-full items-center rounded-2xl border border-transparent bg-lime-200 px-3"
+              class="py-3.75 px-2.75 flex w-full items-center gap-x-3 rounded-2xl border border-transparent bg-lime-200"
             >
               <span class="rounded-lg bg-lime-400 px-2.5 py-1 font-semibold">
                 {getOptionLetter(currentQuestion.answer - 1)}

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -56,28 +56,6 @@
   };
 </script>
 
-{#snippet feedbackAnswer(optionIndex: number)}
-  <div
-    class={[
-      'gap-x-2.75 py-3.75 flex w-full items-center rounded-2xl border border-transparent bg-lime-200 px-3',
-      optionIndex !== currentQuestion.answer - 1 && '!border-slate-950 !bg-white',
-    ]}
-  >
-    <span
-      class={[
-        'rounded-lg bg-lime-400 px-2.5 py-1 font-semibold',
-        optionIndex !== currentQuestion.answer - 1 && '!bg-slate-950 !text-white',
-      ]}
-    >
-      {getOptionLetter(optionIndex)}
-    </span>
-
-    <span class="text-left">
-      {currentQuestion.options[optionIndex]}
-    </span>
-  </div>
-{/snippet}
-
 <header class="fixed inset-x-0 top-0 z-50 bg-slate-100/90 backdrop-blur-sm">
   <div
     class={[
@@ -169,13 +147,41 @@
       <div class="flex flex-col gap-y-6 overflow-y-auto">
         <div class="flex flex-col gap-y-2">
           <span class="font-medium">Your answer</span>
-          {@render feedbackAnswer(selectedOptionIndex)}
+          <div
+            class={[
+              'gap-x-2.75 py-3.75 flex w-full items-center rounded-2xl border border-transparent bg-lime-200 px-3',
+              selectedOptionIndex !== currentQuestion.answer - 1 && '!border-slate-950 !bg-white',
+            ]}
+          >
+            <span
+              class={[
+                'rounded-lg bg-lime-400 px-2.5 py-1 font-semibold',
+                selectedOptionIndex !== currentQuestion.answer - 1 && '!bg-slate-950 !text-white',
+              ]}
+            >
+              {getOptionLetter(selectedOptionIndex)}
+            </span>
+
+            <span class="text-left">
+              {currentQuestion.options[selectedOptionIndex]}
+            </span>
+          </div>
         </div>
 
         {#if !isCorrectAnswer}
           <div class="flex flex-col gap-y-2">
             <span class="font-medium">Correct answer</span>
-            {@render feedbackAnswer(currentQuestion.answer - 1)}
+            <div
+              class="gap-x-2.75 py-3.75 flex w-full items-center rounded-2xl border border-transparent bg-lime-200 px-3"
+            >
+              <span class="rounded-lg bg-lime-400 px-2.5 py-1 font-semibold">
+                {getOptionLetter(currentQuestion.answer - 1)}
+              </span>
+
+              <span class="text-left">
+                {currentQuestion.options[currentQuestion.answer - 1]}
+              </span>
+            </div>
           </div>
         {/if}
         <div class="flex flex-col gap-y-1 rounded-2xl bg-slate-100 p-3">

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -132,7 +132,7 @@
         <span class="text-xl font-medium">{currentQuestion.question}</span>
       </div>
 
-      <div class="flex flex-col items-start gap-y-2">
+      <div class="flex flex-col gap-y-2">
         {#each currentQuestion.options as option, index (option)}
           <button
             class={[

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -159,7 +159,7 @@
         </span>
 
         <button
-          class="cursor-pointer rounded-full bg-slate-100 px-2.5 py-3 hover:bg-slate-200"
+          class="cursor-pointer rounded-full p-4 hover:bg-slate-100"
           onclick={closeFeedbackModal}
         >
           <X />

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -14,14 +14,13 @@
   let currentQuestionIndex = $state(0);
   let isFeedbackModalOpen = $state(false);
   let isCorrectAnswer = $state(false);
+  let target = $state<HTMLElement | null>(null);
 
   let currentQuestion = $derived(data.questionAnswers[currentQuestionIndex]);
   let percentageCompleted = $derived(
     ((currentQuestionIndex + 1) / data.questionAnswers.length) * 100,
   );
   let contentId = $derived(page.params.id);
-
-  let target = $state<HTMLElement | null>(null);
 
   const isWithinViewport = new IsWithinViewport(() => target);
 

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { ArrowLeft, X } from '@lucide/svelte';
+  import { onMount } from 'svelte';
   import { slide } from 'svelte/transition';
 
   import { page } from '$app/state';
@@ -52,6 +53,26 @@
   function closeFeedbackModal() {
     isFeedbackModalOpen = false;
   }
+
+  let isWithinViewport = $state(false);
+
+  let target: HTMLElement | null;
+
+  onMount(() => {
+    const observer = new IntersectionObserver(([entry]) => {
+      isWithinViewport = entry.isIntersecting;
+    });
+
+    if (target) {
+      observer.observe(target);
+    }
+
+    return () => {
+      if (target) {
+        observer.unobserve(target);
+      }
+    };
+  });
 </script>
 
 {#snippet modalFeedbackButton(optionIndex: number)}
@@ -77,83 +98,104 @@
   </div>
 {/snippet}
 
-<div class="flex h-full flex-col gap-y-6 p-6">
-  <div class="flex items-center gap-x-8">
-    <a class="rounded-full bg-slate-200 px-3 py-4" href="/content/{contentId}">
-      <ArrowLeft />
-    </a>
-    <Progress value={percentageCompleted} />
-    <span class="text-sm">{currentQuestionIndex + 1}/{data.questionAnswers.length}</span>
-  </div>
+<header class="fixed inset-x-0 top-0 z-50 bg-slate-100/90 backdrop-blur-sm">
+  <div
+    class={[
+      'absolute inset-x-0 top-full h-px bg-transparent transition-colors duration-300',
+      !isWithinViewport && '!bg-slate-950/7.5',
+    ]}
+  ></div>
 
-  <div class="flex flex-1 flex-col gap-y-6">
-    <span class="text-xl font-medium">{currentQuestion.question}</span>
-    <div class="flex flex-col items-start gap-y-2">
-      {#each currentQuestion.options as option, index (option)}
-        <button
-          class={[
-            'py-4.75 px-2.75 flex w-full cursor-pointer items-center gap-x-3 rounded-2xl border border-transparent bg-white',
-            selectedOptionIndex === index && '!border-black',
-          ]}
-          onclick={() => selectOption(index)}
+  <div class="mx-auto w-full max-w-5xl px-4 py-3">
+    <div class="flex items-center justify-between gap-x-8">
+      <div class="flex w-full items-center gap-x-3">
+        <a
+          href="/content/{contentId}"
+          class="rounded-full p-4 transition-colors hover:bg-slate-200"
         >
-          <span
-            class={[
-              'rounded-lg bg-slate-100 px-2 py-1 text-xs font-semibold',
-              selectedOptionIndex === index && '!bg-slate-900 !text-white',
-            ]}
-          >
-            {getOptionLetter(index)}
-          </span>
-          <span class="text-left">
-            {option}
-          </span>
-        </button>
-      {/each}
-    </div>
-  </div>
-
-  <Button onclick={handleCheckAnswer} disabled={selectedOptionIndex === -1 || isFeedbackModalOpen}>
-    Check Answer
-  </Button>
-
-  {#if isFeedbackModalOpen}
-    <div class="fixed inset-0 flex items-end justify-center">
-      <div
-        class="inset-shadow-sm flex max-h-[70vh] w-full max-w-5xl transform flex-col gap-y-5 rounded-t-3xl bg-white p-5 shadow-lg transition-all"
-        transition:slide={{ axis: 'y' }}
-      >
-        <div class="flex items-center justify-between">
-          <span class="py-2.5 text-xl font-medium">
-            {isCorrectAnswer ? 'Correct answer!' : 'Not quite right!'}
-          </span>
-          <button
-            class="cursor-pointer rounded-full bg-slate-100 px-2.5 py-3 hover:bg-slate-200"
-            onclick={closeFeedbackModal}
-          >
-            <X />
-          </button>
-        </div>
-
-        <div class="flex flex-col gap-y-6 overflow-y-auto">
-          <div class="flex flex-col gap-y-2">
-            <span class="font-medium">Your answer</span>
-            {@render modalFeedbackButton(selectedOptionIndex)}
-          </div>
-          {#if !isCorrectAnswer}
-            <div class="flex flex-col gap-y-2">
-              <span class="font-medium">Correct answer</span>
-              {@render modalFeedbackButton(currentQuestion.answer - 1)}
-            </div>
-          {/if}
-          <div class="flex flex-col gap-y-1 rounded-2xl bg-slate-100 p-3">
-            <span class="font-medium text-zinc-600">Explanation</span>
-            <span>{currentQuestion.explanation}</span>
-          </div>
-        </div>
-
-        <Button onclick={nextQuestion}>Continue</Button>
+          <ArrowLeft />
+        </a>
+        <Progress value={percentageCompleted} />
+        <span class="text-sm">{currentQuestionIndex + 1}/{data.questionAnswers.length}</span>
       </div>
     </div>
-  {/if}
-</div>
+  </div>
+</header>
+
+<main class="pt-23 relative mx-auto min-h-full w-full max-w-5xl px-4 pb-3">
+  <div bind:this={target} class="absolute inset-x-0 top-0 h-px"></div>
+  <div class="flex h-full flex-col">
+    <div class="flex flex-1 flex-col gap-y-6">
+      <span class="text-xl font-medium">{currentQuestion.question}</span>
+      <div class="flex flex-col items-start gap-y-2">
+        {#each currentQuestion.options as option, index (option)}
+          <button
+            class={[
+              'py-4.75 px-2.75 flex w-full cursor-pointer items-center gap-x-3 rounded-2xl border border-transparent bg-white',
+              selectedOptionIndex === index && '!border-black',
+            ]}
+            onclick={() => selectOption(index)}
+          >
+            <span
+              class={[
+                'rounded-lg bg-slate-100 px-2 py-1 text-xs font-semibold',
+                selectedOptionIndex === index && '!bg-slate-900 !text-white',
+              ]}
+            >
+              {getOptionLetter(index)}
+            </span>
+            <span class="text-left">
+              {option}
+            </span>
+          </button>
+        {/each}
+      </div>
+    </div>
+    <Button
+      onclick={handleCheckAnswer}
+      disabled={selectedOptionIndex === -1 || isFeedbackModalOpen}
+    >
+      Check Answer
+    </Button>
+  </div>
+</main>
+
+{#if isFeedbackModalOpen}
+  <div class="fixed inset-0 flex items-end justify-center">
+    <div
+      class="inset-shadow-sm flex max-h-[70vh] w-full max-w-5xl transform flex-col gap-y-5 rounded-t-3xl bg-white px-4 pb-3 pt-4 shadow-lg transition-all"
+      transition:slide={{ axis: 'y' }}
+    >
+      <div class="flex items-center justify-between">
+        <span class="py-2.5 text-xl font-medium">
+          {isCorrectAnswer ? 'Correct answer!' : 'Not quite right!'}
+        </span>
+        <button
+          class="cursor-pointer rounded-full bg-slate-100 px-2.5 py-3 hover:bg-slate-200"
+          onclick={closeFeedbackModal}
+        >
+          <X />
+        </button>
+      </div>
+
+      <div class="flex flex-col gap-y-6 overflow-y-auto">
+        <div class="flex flex-col gap-y-2">
+          <span class="font-medium">Your answer</span>
+          {@render modalFeedbackButton(selectedOptionIndex)}
+        </div>
+        {#if !isCorrectAnswer}
+          <div class="flex flex-col gap-y-2">
+            <span class="font-medium">Correct answer</span>
+            {@render modalFeedbackButton(currentQuestion.answer - 1)}
+          </div>
+        {/if}
+        <div class="flex flex-col gap-y-1 rounded-2xl bg-slate-100 p-3">
+          <span class="font-medium text-zinc-600">Explanation</span>
+          <span>{currentQuestion.explanation}</span>
+        </div>
+      </div>
+
+      <Button onclick={nextQuestion}>Continue</Button>
+    </div>
+  </div>
+{/if}

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -15,12 +15,13 @@
   let isCorrectAnswer = $state(false);
   let isWithinViewport = $state(false);
 
-  let target: HTMLElement | null;
   let currentQuestion = $derived(data.questionAnswers[currentQuestionIndex]);
   let percentageCompleted = $derived(
     ((currentQuestionIndex + 1) / data.questionAnswers.length) * 100,
   );
   let contentId = $derived(page.params.id);
+
+  let target: HTMLElement | null;
 
   onMount(() => {
     const observer = new IntersectionObserver(([entry]) => {

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import { ArrowLeft, X } from '@lucide/svelte';
-  import { onMount } from 'svelte';
   import { slide } from 'svelte/transition';
 
   import { page } from '$app/state';
   import { Badge } from '$lib/components/Badge/index.js';
   import { Button } from '$lib/components/Button/index.js';
   import Progress from '$lib/components/Progress.svelte';
+  import { IsWithinViewport } from '$lib/helpers/index.js';
 
   const { data } = $props();
 
@@ -14,7 +14,6 @@
   let currentQuestionIndex = $state(0);
   let isFeedbackModalOpen = $state(false);
   let isCorrectAnswer = $state(false);
-  let isWithinViewport = $state(false);
 
   let currentQuestion = $derived(data.questionAnswers[currentQuestionIndex]);
   let percentageCompleted = $derived(
@@ -22,23 +21,9 @@
   );
   let contentId = $derived(page.params.id);
 
-  let target: HTMLElement | null;
+  let target = $state<HTMLElement | null>(null);
 
-  onMount(() => {
-    const observer = new IntersectionObserver(([entry]) => {
-      isWithinViewport = entry.isIntersecting;
-    });
-
-    if (target) {
-      observer.observe(target);
-    }
-
-    return () => {
-      if (target) {
-        observer.unobserve(target);
-      }
-    };
-  });
+  const isWithinViewport = new IsWithinViewport(() => target);
 
   const selectOption = (index: number) => {
     selectedOptionIndex = index;
@@ -97,7 +82,7 @@
   <div
     class={[
       'absolute inset-x-0 top-full h-px bg-transparent transition-colors duration-300',
-      !isWithinViewport && '!bg-slate-950/7.5',
+      target && !isWithinViewport.current && '!bg-slate-950/7.5',
     ]}
   ></div>
 

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -86,19 +86,12 @@
     ]}
   ></div>
 
-  <div class="mx-auto w-full max-w-5xl px-4 py-3">
-    <div class="flex items-center justify-between gap-x-8">
-      <div class="flex w-full items-center gap-x-3">
-        <a
-          href="/content/{contentId}"
-          class="rounded-full p-4 transition-colors hover:bg-slate-200"
-        >
-          <ArrowLeft />
-        </a>
+  <div class="mx-auto flex w-full max-w-5xl items-center justify-between gap-x-3 px-4 py-3">
+    <a href="/content/{contentId}" class="rounded-full p-4 transition-colors hover:bg-slate-200">
+      <ArrowLeft />
+    </a>
 
-        <Progress value={percentageCompleted} />
-      </div>
-    </div>
+    <Progress value={percentageCompleted} />
   </div>
 </header>
 

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -85,18 +85,18 @@
         <span class="text-xl font-medium">{currentQuestion.question}</span>
       </div>
 
-      <div class="flex flex-col gap-y-2">
+      <div class="flex flex-col gap-y-2 px-1">
         {#each currentQuestion.options as option, index (option)}
           <button
             class={[
-              'py-3.75 px-2.75 flex w-full cursor-pointer items-center gap-x-3 rounded-2xl border border-transparent bg-white hover:bg-slate-200',
+              'py-3.75 px-2.75 shadow-xs group flex cursor-pointer items-center gap-x-3 rounded-2xl border border-transparent bg-white transition-all hover:bg-slate-50 hover:shadow-sm',
               selectedOptionIndex === index && '!border-slate-950',
             ]}
             onclick={() => selectOption(index)}
           >
             <span
               class={[
-                'rounded-lg bg-slate-100 px-2.5 py-1 font-semibold',
+                'rounded-lg bg-slate-100 px-2.5 py-1 font-semibold transition-colors group-hover:bg-slate-200',
                 selectedOptionIndex === index && '!bg-slate-950 !text-white',
               ]}
             >

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -122,10 +122,10 @@
   </div>
 </header>
 
-<main class="pt-23 relative mx-auto min-h-full w-full max-w-5xl px-4 pb-3">
+<main class="pt-23 pb-23 relative mx-auto min-h-full w-full max-w-5xl px-4">
   <div bind:this={target} class="absolute inset-x-0 top-0 h-px"></div>
   <div class="flex h-full flex-col">
-    <div class="flex flex-1 flex-col gap-y-6">
+    <div class="flex flex-1 flex-col gap-y-6 overflow-y-auto">
       <span class="text-xl font-medium">{currentQuestion.question}</span>
       <div class="flex flex-col items-start gap-y-2">
         {#each currentQuestion.options as option, index (option)}
@@ -151,6 +151,11 @@
         {/each}
       </div>
     </div>
+  </div>
+</main>
+
+<div class="fixed inset-x-0 bottom-0 z-50 bg-slate-100/90 backdrop-blur-sm">
+  <div class="mx-auto w-full max-w-5xl px-4 py-3">
     <Button
       onclick={handleCheckAnswer}
       disabled={selectedOptionIndex === -1 || isFeedbackModalOpen}
@@ -158,7 +163,7 @@
       Check Answer
     </Button>
   </div>
-</main>
+</div>
 
 {#if isFeedbackModalOpen}
   <div class="fixed inset-0 flex items-end justify-center">

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -152,18 +152,18 @@
       </div>
     </div>
   </div>
-</main>
 
-<div class="fixed inset-x-0 bottom-0 z-50 bg-slate-100/90 backdrop-blur-sm">
-  <div class="mx-auto w-full max-w-5xl px-4 py-3">
-    <Button
-      onclick={handleCheckAnswer}
-      disabled={selectedOptionIndex === -1 || isFeedbackModalOpen}
-    >
-      Check Answer
-    </Button>
+  <div class="absolute inset-x-0 bottom-0 z-50 bg-slate-100/90 backdrop-blur-sm">
+    <div class="mx-auto px-4 py-3">
+      <Button
+        onclick={handleCheckAnswer}
+        disabled={selectedOptionIndex === -1 || isFeedbackModalOpen}
+      >
+        Check Answer
+      </Button>
+    </div>
   </div>
-</div>
+</main>
 
 {#if isFeedbackModalOpen}
   <div class="z-100 fixed inset-0 flex items-end justify-center">

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -11,18 +11,32 @@
 
   let selectedOptionIndex = $state(-1);
   let currentQuestionIndex = $state(0);
+  let isFeedbackModalOpen = $state(false);
+  let isCorrectAnswer = $state(false);
+  let isWithinViewport = $state(false);
 
+  let target: HTMLElement | null;
   let currentQuestion = $derived(data.questionAnswers[currentQuestionIndex]);
-
   let percentageCompleted = $derived(
     ((currentQuestionIndex + 1) / data.questionAnswers.length) * 100,
   );
+  let contentId = $derived(page.params.id);
 
-  let isFeedbackModalOpen = $state(false);
+  onMount(() => {
+    const observer = new IntersectionObserver(([entry]) => {
+      isWithinViewport = entry.isIntersecting;
+    });
 
-  let isCorrectAnswer = $state(false);
+    if (target) {
+      observer.observe(target);
+    }
 
-  const contentId = $derived(page.params.id);
+    return () => {
+      if (target) {
+        observer.unobserve(target);
+      }
+    };
+  });
 
   function selectOption(index: number) {
     selectedOptionIndex = index;
@@ -53,26 +67,6 @@
   function closeFeedbackModal() {
     isFeedbackModalOpen = false;
   }
-
-  let isWithinViewport = $state(false);
-
-  let target: HTMLElement | null;
-
-  onMount(() => {
-    const observer = new IntersectionObserver(([entry]) => {
-      isWithinViewport = entry.isIntersecting;
-    });
-
-    if (target) {
-      observer.observe(target);
-    }
-
-    return () => {
-      if (target) {
-        observer.unobserve(target);
-      }
-    };
-  });
 </script>
 
 {#snippet modalFeedbackButton(optionIndex: number)}
@@ -91,6 +85,7 @@
       >
         {getOptionLetter(optionIndex)}
       </span>
+
       <span class="text-left">
         {currentQuestion.options[optionIndex]}
       </span>
@@ -115,7 +110,9 @@
         >
           <ArrowLeft />
         </a>
+
         <Progress value={percentageCompleted} />
+
         <span class="text-sm">{currentQuestionIndex + 1}/{data.questionAnswers.length}</span>
       </div>
     </div>
@@ -124,9 +121,11 @@
 
 <main class="pt-23 pb-23 relative mx-auto min-h-full w-full max-w-5xl px-4">
   <div bind:this={target} class="absolute inset-x-0 top-0 h-px"></div>
+
   <div class="flex h-full flex-col">
     <div class="flex flex-1 flex-col gap-y-6 overflow-y-auto">
       <span class="text-xl font-medium">{currentQuestion.question}</span>
+
       <div class="flex flex-col items-start gap-y-2">
         {#each currentQuestion.options as option, index (option)}
           <button
@@ -144,6 +143,7 @@
             >
               {getOptionLetter(index)}
             </span>
+
             <span class="text-left">
               {option}
             </span>

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -4,6 +4,7 @@
   import { slide } from 'svelte/transition';
 
   import { page } from '$app/state';
+  import { Badge } from '$lib/components/Badge/index.js';
   import { Button } from '$lib/components/Button/index.js';
   import Progress from '$lib/components/Progress.svelte';
 
@@ -74,14 +75,14 @@
   <div class="flex flex-col items-start">
     <button
       class={[
-        'gap-x-2.75 flex w-full items-center rounded-2xl bg-lime-200 p-3',
-        optionIndex !== currentQuestion.answer - 1 && '!bg-slate-100',
+        'gap-x-2.75 py-3.75 flex w-full items-center rounded-2xl border border-transparent bg-lime-200 px-3',
+        optionIndex !== currentQuestion.answer - 1 && '!border-slate-950 !bg-white',
       ]}
     >
       <span
         class={[
-          'rounded-lg bg-lime-400 px-2 py-1 text-xs font-semibold',
-          optionIndex !== currentQuestion.answer - 1 && '!bg-slate-900 !text-white',
+          'rounded-lg bg-lime-400 px-2.5 py-1 font-semibold',
+          optionIndex !== currentQuestion.answer - 1 && '!bg-slate-950 !text-white',
         ]}
       >
         {getOptionLetter(optionIndex)}
@@ -113,8 +114,6 @@
         </a>
 
         <Progress value={percentageCompleted} />
-
-        <span class="text-sm">{currentQuestionIndex + 1}/{data.questionAnswers.length}</span>
       </div>
     </div>
   </div>
@@ -125,21 +124,27 @@
 
   <div class="flex h-full flex-col">
     <div class="flex flex-1 flex-col gap-y-6 overflow-y-auto">
-      <span class="text-xl font-medium">{currentQuestion.question}</span>
+      <div class="flex flex-col gap-y-2">
+        <Badge variant="slate">
+          Question {currentQuestionIndex + 1} of {data.questionAnswers.length}
+        </Badge>
+
+        <span class="text-xl font-medium">{currentQuestion.question}</span>
+      </div>
 
       <div class="flex flex-col items-start gap-y-2">
         {#each currentQuestion.options as option, index (option)}
           <button
             class={[
-              'py-4.75 px-2.75 flex w-full cursor-pointer items-center gap-x-3 rounded-2xl border border-transparent bg-white hover:border-black',
-              selectedOptionIndex === index && '!border-black',
+              'py-3.75 px-2.75 flex w-full cursor-pointer items-center gap-x-3 rounded-2xl border border-transparent bg-white hover:bg-slate-200',
+              selectedOptionIndex === index && '!border-slate-950',
             ]}
             onclick={() => selectOption(index)}
           >
             <span
               class={[
-                'rounded-lg bg-slate-100 px-2 py-1 text-xs font-semibold',
-                selectedOptionIndex === index && '!bg-slate-900 !text-white',
+                'rounded-lg bg-slate-100 px-2.5 py-1 font-semibold',
+                selectedOptionIndex === index && '!bg-slate-950 !text-white',
               ]}
             >
               {getOptionLetter(index)}
@@ -176,6 +181,7 @@
         <span class="py-2.5 text-xl font-medium">
           {isCorrectAnswer ? 'Correct answer!' : 'Not quite right!'}
         </span>
+
         <button
           class="cursor-pointer rounded-full bg-slate-100 px-2.5 py-3 hover:bg-slate-200"
           onclick={closeFeedbackModal}
@@ -189,6 +195,7 @@
           <span class="font-medium">Your answer</span>
           {@render modalFeedbackButton(selectedOptionIndex)}
         </div>
+
         {#if !isCorrectAnswer}
           <div class="flex flex-col gap-y-2">
             <span class="font-medium">Correct answer</span>
@@ -197,6 +204,7 @@
         {/if}
         <div class="flex flex-col gap-y-1 rounded-2xl bg-slate-100 p-3">
           <span class="font-medium text-zinc-600">Explanation</span>
+
           <span>{currentQuestion.explanation}</span>
         </div>
       </div>

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -40,15 +40,15 @@
     };
   });
 
-  function selectOption(index: number) {
+  const selectOption = (index: number) => {
     selectedOptionIndex = index;
-  }
+  };
 
-  function getOptionLetter(index: number) {
+  const getOptionLetter = (index: number) => {
     return String.fromCharCode(65 + index);
-  }
+  };
 
-  function nextQuestion() {
+  const nextQuestion = () => {
     if (selectedOptionIndex !== -1) {
       if (currentQuestionIndex < data.questionAnswers.length - 1) {
         currentQuestionIndex++;
@@ -59,16 +59,16 @@
         console.log('Quiz completed!');
       }
     }
-  }
+  };
 
-  function handleCheckAnswer() {
+  const handleCheckAnswer = () => {
     isCorrectAnswer = selectedOptionIndex + 1 === currentQuestion.answer;
     isFeedbackModalOpen = true;
-  }
+  };
 
-  function closeFeedbackModal() {
+  const closeFeedbackModal = () => {
     isFeedbackModalOpen = false;
-  }
+  };
 </script>
 
 {#snippet modalFeedbackButton(optionIndex: number)}

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -166,7 +166,7 @@
 </div>
 
 {#if isFeedbackModalOpen}
-  <div class="fixed inset-0 flex items-end justify-center">
+  <div class="z-100 fixed inset-0 flex items-end justify-center">
     <div
       class="inset-shadow-sm flex max-h-[70vh] w-full max-w-5xl transform flex-col gap-y-5 rounded-t-3xl bg-white px-4 pb-3 pt-4 shadow-lg transition-all"
       transition:slide={{ axis: 'y' }}

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -71,27 +71,25 @@
   };
 </script>
 
-{#snippet modalFeedbackButton(optionIndex: number)}
-  <div class="flex flex-col items-start">
-    <button
+{#snippet feedbackAnswer(optionIndex: number)}
+  <div
+    class={[
+      'gap-x-2.75 py-3.75 flex w-full items-center rounded-2xl border border-transparent bg-lime-200 px-3',
+      optionIndex !== currentQuestion.answer - 1 && '!border-slate-950 !bg-white',
+    ]}
+  >
+    <span
       class={[
-        'gap-x-2.75 py-3.75 flex w-full items-center rounded-2xl border border-transparent bg-lime-200 px-3',
-        optionIndex !== currentQuestion.answer - 1 && '!border-slate-950 !bg-white',
+        'rounded-lg bg-lime-400 px-2.5 py-1 font-semibold',
+        optionIndex !== currentQuestion.answer - 1 && '!bg-slate-950 !text-white',
       ]}
     >
-      <span
-        class={[
-          'rounded-lg bg-lime-400 px-2.5 py-1 font-semibold',
-          optionIndex !== currentQuestion.answer - 1 && '!bg-slate-950 !text-white',
-        ]}
-      >
-        {getOptionLetter(optionIndex)}
-      </span>
+      {getOptionLetter(optionIndex)}
+    </span>
 
-      <span class="text-left">
-        {currentQuestion.options[optionIndex]}
-      </span>
-    </button>
+    <span class="text-left">
+      {currentQuestion.options[optionIndex]}
+    </span>
   </div>
 {/snippet}
 
@@ -193,13 +191,13 @@
       <div class="flex flex-col gap-y-6 overflow-y-auto">
         <div class="flex flex-col gap-y-2">
           <span class="font-medium">Your answer</span>
-          {@render modalFeedbackButton(selectedOptionIndex)}
+          {@render feedbackAnswer(selectedOptionIndex)}
         </div>
 
         {#if !isCorrectAnswer}
           <div class="flex flex-col gap-y-2">
             <span class="font-medium">Correct answer</span>
-            {@render modalFeedbackButton(currentQuestion.answer - 1)}
+            {@render feedbackAnswer(currentQuestion.answer - 1)}
           </div>
         {/if}
         <div class="flex flex-col gap-y-1 rounded-2xl bg-slate-100 p-3">

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -141,18 +141,18 @@
       </div>
     </div>
   </div>
-
-  <div class="absolute inset-x-0 bottom-0 z-50 bg-slate-100/90 backdrop-blur-sm">
-    <div class="mx-auto px-4 py-3">
-      <Button
-        onclick={handleCheckAnswer}
-        disabled={selectedOptionIndex === -1 || isFeedbackModalOpen}
-      >
-        Check Answer
-      </Button>
-    </div>
-  </div>
 </main>
+
+<div class="fixed inset-x-0 bottom-0 z-50 bg-slate-100/90 backdrop-blur-sm">
+  <div class="mx-auto w-full max-w-5xl px-4 py-3">
+    <Button
+      onclick={handleCheckAnswer}
+      disabled={selectedOptionIndex === -1 || isFeedbackModalOpen}
+    >
+      Check Answer
+    </Button>
+  </div>
+</div>
 
 {#if isFeedbackModalOpen}
   <div class="z-100 fixed inset-0 flex items-end justify-center">

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -168,7 +168,7 @@
 {#if isFeedbackModalOpen}
   <div class="z-100 fixed inset-0 flex items-end justify-center">
     <div
-      class="inset-shadow-sm flex max-h-[70vh] w-full max-w-5xl transform flex-col gap-y-5 rounded-t-3xl bg-white px-4 pb-3 pt-4 shadow-lg transition-all"
+      class="inset-shadow-sm flex max-h-[70vh] w-full max-w-5xl transform flex-col gap-y-5 rounded-t-3xl bg-white px-4 py-3 shadow-lg transition-all"
       transition:slide={{ axis: 'y' }}
     >
       <div class="flex items-center justify-between">

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -130,7 +130,7 @@
         {#each currentQuestion.options as option, index (option)}
           <button
             class={[
-              'py-4.75 px-2.75 flex w-full cursor-pointer items-center gap-x-3 rounded-2xl border border-transparent bg-white',
+              'py-4.75 px-2.75 flex w-full cursor-pointer items-center gap-x-3 rounded-2xl border border-transparent bg-white hover:border-black',
               selectedOptionIndex === index && '!border-black',
             ]}
             onclick={() => selectOption(index)}


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->
This PR aims to standardise the layout of quiz with the rest of the learner app (reference with #111)

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->
- removed layout file since there's no reusability with other non-quiz related pages
- applied styling on feedback modal to also follow the same layout styling
- updated the Back button styling to use a circular shape instead of the existing oval-ish shape (note this is only applied on quiz and not on the rest of the app, which will be handled in a separate change)
- made the Check Answer sticky at the bottom as per discussion with Wondo
- added z-index for feedback modal
- updated design based on latest figma updates