### PR TITLE
fix(learner): stop header bottom line from flashing on page load

### DIFF
--- a/apps/learner/src/routes/(app)/+layout.svelte
+++ b/apps/learner/src/routes/(app)/+layout.svelte
@@ -6,7 +6,7 @@
 
   const { children } = $props();
 
-  let isWithinViewport = $state(false);
+  let isWithinViewport = $state(true);
 
   const isHomePage = $derived(page.url.pathname === '/');
   const isLearningPage = $derived(page.url.pathname === '/learning');

--- a/apps/learner/src/routes/collection/[id]/+page.svelte
+++ b/apps/learner/src/routes/collection/[id]/+page.svelte
@@ -4,7 +4,7 @@
 
   import LearningUnit from '$lib/components/LearningUnit.svelte';
 
-  let isWithinViewport = $state(false);
+  let isWithinViewport = $state(true);
 
   let target: HTMLElement | null;
 

--- a/apps/learner/src/routes/content/[id]/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/+page.svelte
@@ -10,7 +10,7 @@
   const { data } = $props();
 
   let returnTo = $state('/');
-  let isWithinViewport = $state(false);
+  let isWithinViewport = $state(true);
   let isExpanded = $state(false);
 
   let target: HTMLElement | null;


### PR DESCRIPTION
## 🚀 Summary

This PR fixes a bug causing the header’s bottom line to flash on page load.

## ✏️ Changes

- Changed the default state of `isWithinViewport` from `false` to `true`
