### PR TITLE
feat(learner): update play button and revert previous layout change in `LearningUnit` component

### DIFF
--- a/apps/learner/src/lib/components/Button/Button.svelte
+++ b/apps/learner/src/lib/components/Button/Button.svelte
@@ -20,9 +20,9 @@
     /**
      * The width of the button.
      *
-     * @default 'full'
+     * @default 'fit'
      */
-    width?: 'full' | 'auto';
+    width?: 'fit' | 'full';
     /**
      * Indicates whether the button is disabled.
      *
@@ -34,7 +34,7 @@
   const {
     variant = 'primary',
     size = 'lg',
-    width = 'full',
+    width = 'fit',
     disabled = false,
     children,
     class: clazz,
@@ -52,8 +52,8 @@
       variant === 'secondary' && 'border-slate-300 bg-white text-slate-950 hover:bg-slate-100',
       size === 'md' && 'py-2.75',
       size === 'lg' && 'py-3',
+      width === 'fit' && 'w-fit',
       width === 'full' && 'w-full',
-      width === 'auto' && 'w-auto',
       clazz,
     ]}
   >
@@ -70,8 +70,8 @@
       variant === 'secondary' && 'border-slate-300 bg-white text-slate-950 hover:bg-slate-100',
       size === 'md' && 'py-2.75',
       size === 'lg' && 'py-3',
+      width === 'fit' && 'w-fit',
       width === 'full' && 'w-full',
-      width === 'auto' && 'w-auto',
       clazz,
     ]}
   >

--- a/apps/learner/src/lib/components/Button/Button.svelte
+++ b/apps/learner/src/lib/components/Button/Button.svelte
@@ -18,6 +18,12 @@
      */
     size?: 'md' | 'lg';
     /**
+     * The width of the button.
+     *
+     * @default 'full'
+     */
+    width?: 'full' | 'auto';
+    /**
      * Indicates whether the button is disabled.
      *
      * @default false
@@ -28,6 +34,7 @@
   const {
     variant = 'primary',
     size = 'lg',
+    width = 'full',
     disabled = false,
     children,
     class: clazz,
@@ -40,11 +47,13 @@
     {...otherProps}
     aria-disabled={disabled}
     class={[
-      'flex w-full cursor-pointer items-center justify-center gap-x-1 rounded-full border px-4 transition-colors aria-disabled:pointer-events-none aria-disabled:border-transparent aria-disabled:bg-slate-900/50 aria-disabled:text-white',
+      'flex cursor-pointer items-center justify-center gap-x-1 rounded-full border px-4 transition-colors aria-disabled:pointer-events-none aria-disabled:border-transparent aria-disabled:bg-slate-900/50 aria-disabled:text-white',
       variant === 'primary' && 'border-transparent bg-slate-950 text-white hover:bg-slate-900/90',
       variant === 'secondary' && 'border-slate-300 bg-white text-slate-950 hover:bg-slate-100',
       size === 'md' && 'py-2.75',
       size === 'lg' && 'py-3',
+      width === 'full' && 'w-full',
+      width === 'auto' && 'w-auto',
       clazz,
     ]}
   >
@@ -56,11 +65,13 @@
     aria-disabled={disabled}
     {disabled}
     class={[
-      'flex w-full cursor-pointer items-center justify-center gap-x-1 rounded-full border px-4 transition-colors aria-disabled:pointer-events-none aria-disabled:border-transparent aria-disabled:bg-slate-900/50 aria-disabled:text-white',
+      'flex cursor-pointer items-center justify-center gap-x-1 rounded-full border px-4 transition-colors aria-disabled:pointer-events-none aria-disabled:border-transparent aria-disabled:bg-slate-900/50 aria-disabled:text-white',
       variant === 'primary' && 'border-transparent bg-slate-950 text-white hover:bg-slate-900/90',
       variant === 'secondary' && 'border-slate-300 bg-white text-slate-950 hover:bg-slate-100',
       size === 'md' && 'py-2.75',
       size === 'lg' && 'py-3',
+      width === 'full' && 'w-full',
+      width === 'auto' && 'w-auto',
       clazz,
     ]}
   >

--- a/apps/learner/src/lib/components/LearningUnit.svelte
+++ b/apps/learner/src/lib/components/LearningUnit.svelte
@@ -59,7 +59,7 @@
   </div>
 
   {#if showplayerpanel}
-    <div class="flex items-center justify-between">
+    <div class="flex items-center gap-x-3">
       <button
         class="flex cursor-pointer items-center gap-x-2 rounded-full bg-slate-100 px-6 py-4 transition-colors hover:bg-slate-200"
         onclick={handlePlay}
@@ -69,8 +69,6 @@
       </button>
 
       <div class="flex items-center gap-x-2">
-        <span class="text-sm text-slate-600">23m left</span>
-
         <svg viewBox="0 0 24 24" class="h-6 w-6">
           <circle cx="12" cy="12" r="9" stroke="#E2E8F0" fill="none" stroke-width="3px" />
           <circle
@@ -86,6 +84,8 @@
             transform="rotate(-90 0 0)"
           />
         </svg>
+
+        <span class="text-sm text-slate-600">23m left</span>
       </div>
     </div>
   {/if}

--- a/apps/learner/src/lib/components/LearningUnit.svelte
+++ b/apps/learner/src/lib/components/LearningUnit.svelte
@@ -62,7 +62,7 @@
   {#if showplayerpanel}
     <div class="flex items-center gap-x-3">
       <Button variant="secondary" onclick={handlePlay}>
-        <Play />
+        <Play class="h-4 w-4" />
         <span class="font-medium">Play</span>
       </Button>
 

--- a/apps/learner/src/lib/components/LearningUnit.svelte
+++ b/apps/learner/src/lib/components/LearningUnit.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { Play } from '@lucide/svelte';
-  import type { MouseEventHandler } from 'svelte/elements';
 
   import { Badge, type BadgeProps } from '$lib/components/Badge/index.js';
+  import { Button } from '$lib/components/Button/index.js';
 
   interface Props {
     /**
@@ -20,7 +20,7 @@
     /**
      * A callback function that is called when the user clicks on the play button.
      */
-    onplay?: MouseEventHandler<HTMLButtonElement>;
+    onplay?: () => void;
     /**
      * A flag to display the panel containing the Play button and progress indicator.
      */
@@ -29,11 +29,8 @@
 
   let { to, title, tags, onplay, showplayerpanel = false }: Props = $props();
 
-  const handlePlay: MouseEventHandler<HTMLButtonElement> = (event) => {
-    // Prevent the default behavior of the anchor tag from navigating to the URL.
-    event.preventDefault();
-
-    onplay?.(event);
+  const handlePlay = () => {
+    onplay?.();
   };
 </script>
 
@@ -60,13 +57,10 @@
 
   {#if showplayerpanel}
     <div class="flex items-center gap-x-3">
-      <button
-        class="flex cursor-pointer items-center gap-x-2 rounded-full bg-slate-100 px-6 py-4 transition-colors hover:bg-slate-200"
-        onclick={handlePlay}
-      >
+      <Button variant="secondary" size="lg" width="auto" onclick={handlePlay}>
         <Play />
         <span class="font-medium text-slate-950">Play</span>
-      </button>
+      </Button>
 
       <div class="flex items-center gap-x-2">
         <svg viewBox="0 0 24 24" class="h-6 w-6">

--- a/apps/learner/src/lib/components/LearningUnit.svelte
+++ b/apps/learner/src/lib/components/LearningUnit.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Play } from '@lucide/svelte';
+  import type { MouseEventHandler } from 'svelte/elements';
 
   import { Badge, type BadgeProps } from '$lib/components/Badge/index.js';
   import { Button } from '$lib/components/Button/index.js';
@@ -20,7 +21,7 @@
     /**
      * A callback function that is called when the user clicks on the play button.
      */
-    onplay?: () => void;
+    onplay?: MouseEventHandler<HTMLButtonElement>;
     /**
      * A flag to display the panel containing the Play button and progress indicator.
      */
@@ -29,8 +30,11 @@
 
   let { to, title, tags, onplay, showplayerpanel = false }: Props = $props();
 
-  const handlePlay = () => {
-    onplay?.();
+  const handlePlay: MouseEventHandler<HTMLButtonElement> = (event) => {
+    // Prevent the default behavior of the anchor tag from navigating to the URL.
+    event.preventDefault();
+
+    onplay?.(event);
   };
 </script>
 

--- a/apps/learner/src/lib/components/LearningUnit.svelte
+++ b/apps/learner/src/lib/components/LearningUnit.svelte
@@ -57,9 +57,9 @@
 
   {#if showplayerpanel}
     <div class="flex items-center gap-x-3">
-      <Button variant="secondary" size="lg" width="auto" onclick={handlePlay}>
+      <Button variant="secondary" onclick={handlePlay}>
         <Play />
-        <span class="font-medium text-slate-950">Play</span>
+        <span class="font-medium">Play</span>
       </Button>
 
       <div class="flex items-center gap-x-2">

--- a/apps/learner/src/routes/content/[id]/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/+page.svelte
@@ -77,12 +77,12 @@
         </div>
 
         <div class="flex flex-col gap-y-4">
-          <Button size="md">
+          <Button size="md" width="full">
             <Play class="h-4 w-4" />
             <span class="font-medium">Play</span>
           </Button>
 
-          <Button href={`/content/${data.id}/quiz`} variant="secondary" size="md">
+          <Button variant="secondary" size="md" width="full" href={`/content/${data.id}/quiz`}>
             <Lightbulb class="h-4 w-4" />
             <span class="font-medium">Take the quiz</span>
           </Button>

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -116,8 +116,9 @@
 <div class="fixed inset-x-0 bottom-0 z-50 bg-slate-100/90 backdrop-blur-sm">
   <div class="mx-auto w-full max-w-5xl px-4 py-3">
     <Button
-      onclick={handleCheckAnswer}
+      width="full"
       disabled={selectedOptionIndex === -1 || isFeedbackModalOpen}
+      onclick={handleCheckAnswer}
     >
       Check Answer
     </Button>
@@ -190,7 +191,7 @@
         </div>
       </div>
 
-      <Button onclick={nextQuestion}>Continue</Button>
+      <Button width="full" onclick={nextQuestion}>Continue</Button>
     </div>
   </div>
 {/if}


### PR DESCRIPTION
Closes #133

## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

This update reverts a previous layout change to the `LearningUnit` progress indicator (https://github.com/String-sg/onward/pull/116) and applies visual improvements to the play button. The goal is to maintain a consistent UI while refining the visual experience for learners.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- **Reverted**: feat(learner): reposition the LearningUnit progress indicator (#116)
- Updated the play button with new background color and border styling for improved contrast and clarity
- Reduce `Play` icon size from `24x24` to `16x16` in `LearningUnit` component