### PR TITLE
fix(learner): remove white bg that's causing the removal of glass effect

### DIFF
--- a/apps/learner/src/lib/components/FloatingChat.svelte
+++ b/apps/learner/src/lib/components/FloatingChat.svelte
@@ -1,5 +1,5 @@
 <button
-  class="inset-shadow-sm inset-shadow-slate-100 flex items-center rounded-full border border-slate-100 p-5 shadow-lg backdrop-blur-sm"
+  class="inset-shadow-sm inset-shadow-slate-200 flex items-center rounded-full border border-slate-100 p-5 shadow-lg backdrop-blur-sm"
 >
   <!-- Icon SVG -->
   <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" fill="none">

--- a/apps/learner/src/lib/components/FloatingChat.svelte
+++ b/apps/learner/src/lib/components/FloatingChat.svelte
@@ -1,5 +1,5 @@
 <button
-  class="inset-shadow-sm flex items-center rounded-full bg-white/90 p-5 shadow-lg backdrop-blur-sm"
+  class="inset-shadow-sm inset-shadow-slate-100 flex items-center rounded-full border border-slate-100 p-5 shadow-lg backdrop-blur-sm"
 >
   <!-- Icon SVG -->
   <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" fill="none">

--- a/apps/learner/src/lib/components/FloatingPlayer.svelte
+++ b/apps/learner/src/lib/components/FloatingPlayer.svelte
@@ -33,7 +33,7 @@
 
 <a
   href={to}
-  class="inset-shadow-sm flex items-center gap-x-3 rounded-full bg-white/90 p-3 shadow-lg backdrop-blur-sm"
+  class="inset-shadow-sm inset-shadow-slate-200 flex items-center gap-x-3 rounded-full border border-slate-100 p-3 shadow-lg backdrop-blur-sm"
 >
   <!-- Temporary album placeholder -->
   <div class="h-12 w-12 rounded-full bg-black"></div>


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->
This PR aims to remove the white background that's causing the glass effect to disappear. This was an aftereffect from #123 where during refactor of the floating container, the styling of the buttons got changed unintentionally

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->
- remove white background
- added `inset-shadow-slate-200` and `border border-zinc-200` to make the floating components more distinct