### PR TITLE
refactor(learner): folderise `Badge` and `Button` components

### DIFF
--- a/apps/learner/src/lib/components/Badge/Badge.svelte
+++ b/apps/learner/src/lib/components/Badge/Badge.svelte
@@ -2,14 +2,12 @@
   import type { Snippet } from 'svelte';
   import type { HTMLAttributes } from 'svelte/elements';
 
-  export type Variant = 'blue' | 'orange' | 'amber' | 'teal' | 'rose' | 'purple' | 'slate';
-
-  interface Props extends HTMLAttributes<HTMLDivElement> {
-    variant: Variant;
+  export interface Props extends HTMLAttributes<HTMLDivElement> {
+    variant: 'blue' | 'orange' | 'amber' | 'teal' | 'rose' | 'purple' | 'slate';
     children: Snippet;
   }
 
-  let { children, variant, class: clazz, ...otherProps }: Props = $props();
+  let { variant, children, class: clazz, ...otherProps }: Props = $props();
 </script>
 
 <div

--- a/apps/learner/src/lib/components/Badge/index.ts
+++ b/apps/learner/src/lib/components/Badge/index.ts
@@ -1,0 +1,1 @@
+export { default as Badge, type Props as BadgeProps } from './Badge.svelte';

--- a/apps/learner/src/lib/components/Button/Button.svelte
+++ b/apps/learner/src/lib/components/Button/Button.svelte
@@ -1,27 +1,29 @@
 <script lang="ts">
   import type { HTMLAnchorAttributes, HTMLButtonAttributes } from 'svelte/elements';
 
-  type ButtonProps = Omit<HTMLButtonAttributes, 'disabled' | 'aria-disabled'> &
-    Omit<HTMLAnchorAttributes, 'aria-disabled'> & {
-      /**
-       * The variant of the button.
-       *
-       * @default 'primary'
-       */
-      variant?: 'primary' | 'secondary';
-      /**
-       * The size of the button.
-       *
-       * @default 'lg'
-       */
-      size?: 'md' | 'lg';
-      /**
-       * Indicates whether the button is disabled.
-       *
-       * @default false
-       */
-      disabled?: boolean;
-    };
+  export type Props = (
+    | Omit<HTMLButtonAttributes, 'disabled' | 'aria-disabled'>
+    | ({ href: string } & Omit<HTMLAnchorAttributes, 'href' | 'aria-disabled'>)
+  ) & {
+    /**
+     * The variant of the button.
+     *
+     * @default 'primary'
+     */
+    variant?: 'primary' | 'secondary';
+    /**
+     * The size of the button.
+     *
+     * @default 'lg'
+     */
+    size?: 'md' | 'lg';
+    /**
+     * Indicates whether the button is disabled.
+     *
+     * @default false
+     */
+    disabled?: boolean;
+  };
 
   const {
     variant = 'primary',
@@ -30,7 +32,7 @@
     children,
     class: clazz,
     ...otherProps
-  }: ButtonProps = $props();
+  }: Props = $props();
 </script>
 
 {#if 'href' in otherProps}

--- a/apps/learner/src/lib/components/Button/index.ts
+++ b/apps/learner/src/lib/components/Button/index.ts
@@ -1,0 +1,1 @@
+export { default as Button, type Props as ButtonProps } from './Button.svelte';

--- a/apps/learner/src/lib/components/Collection.svelte
+++ b/apps/learner/src/lib/components/Collection.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   export type Variant = 'purple' | 'teal' | 'amber';
 
-  import Badge from '$lib/components/Badge.svelte';
+  import { Badge } from '$lib/components/Badge/index.js';
 
   interface Props {
     /**

--- a/apps/learner/src/lib/components/LearningUnit.svelte
+++ b/apps/learner/src/lib/components/LearningUnit.svelte
@@ -2,7 +2,7 @@
   import { Play } from '@lucide/svelte';
   import type { MouseEventHandler } from 'svelte/elements';
 
-  import Badge, { type Variant as BadgeVariant } from '$lib/components/Badge.svelte';
+  import { Badge, type BadgeProps } from '$lib/components/Badge/index.js';
 
   interface Props {
     /**
@@ -12,7 +12,7 @@
     /**
      * The tags to display on the MLU.
      */
-    tags: { variant: BadgeVariant; content: string }[];
+    tags: { variant: BadgeProps['variant']; content: string }[];
     /**
      * The title of the MLU.
      */

--- a/apps/learner/src/routes/content/[id]/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/+page.svelte
@@ -3,7 +3,7 @@
   import { formatDistanceToNow } from 'date-fns';
 
   import { afterNavigate } from '$app/navigation';
-  import Badge from '$lib/components/Badge.svelte';
+  import { Badge } from '$lib/components/Badge/index.js';
   import Button from '$lib/components/Button.svelte';
   import { IsWithinViewport } from '$lib/helpers/index.js';
 

--- a/apps/learner/src/routes/content/[id]/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/+page.svelte
@@ -4,7 +4,7 @@
 
   import { afterNavigate } from '$app/navigation';
   import { Badge } from '$lib/components/Badge/index.js';
-  import Button from '$lib/components/Button.svelte';
+  import { Button } from '$lib/components/Button/index.js';
   import { IsWithinViewport } from '$lib/helpers/index.js';
 
   const { data } = $props();

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -3,7 +3,7 @@
   import { slide } from 'svelte/transition';
 
   import { page } from '$app/state';
-  import Button from '$lib/components/Button.svelte';
+  import { Button } from '$lib/components/Button/index.js';
   import Progress from '$lib/components/Progress.svelte';
 
   const { data } = $props();


### PR DESCRIPTION
## 🚀 Summary

This PR introduces a folder-per-component structure, specifically for `Badge` and `Button` components. Another PR will address the remaining components. Having a dedicated folder per component helps keep things more organised, especially when adding tests or handling components with multiple sub-components.

## ✏️ Changes

- Moved `Badge` and `Button` components into their own folders
