### PR TITLE
feat(learner): add focus effect to navigation buttons and adjust their padding from `px-3 py-4` to `p-4` on `Collection` and `LearningUnit` pages

### DIFF
--- a/apps/learner/src/routes/collection/[id]/+page.svelte
+++ b/apps/learner/src/routes/collection/[id]/+page.svelte
@@ -22,7 +22,7 @@
       <div class="flex items-center gap-x-3">
         <a
           href="/learning"
-          class="rounded-full p-4 transition-colors hover:bg-slate-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+          class="rounded-full p-4 transition-colors hover:bg-slate-200 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
         >
           <ArrowLeft />
         </a>

--- a/apps/learner/src/routes/collection/[id]/+page.svelte
+++ b/apps/learner/src/routes/collection/[id]/+page.svelte
@@ -20,7 +20,10 @@
   <div class="mx-auto w-full max-w-5xl px-4 py-3">
     <div class="flex items-center justify-between gap-x-8">
       <div class="flex items-center gap-x-3">
-        <a href="/learning" class="rounded-full p-4 transition-colors hover:bg-slate-200">
+        <a
+          href="/learning"
+          class="rounded-full p-4 transition-colors hover:bg-slate-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+        >
           <ArrowLeft />
         </a>
 

--- a/apps/learner/src/routes/collection/[id]/+page.svelte
+++ b/apps/learner/src/routes/collection/[id]/+page.svelte
@@ -20,7 +20,7 @@
   <div class="mx-auto w-full max-w-5xl px-4 py-3">
     <div class="flex items-center justify-between gap-x-8">
       <div class="flex items-center gap-x-3">
-        <a href="/learning" class="rounded-full px-3 py-4 transition-colors hover:bg-slate-200">
+        <a href="/learning" class="rounded-full p-4 transition-colors hover:bg-slate-200">
           <ArrowLeft />
         </a>
 

--- a/apps/learner/src/routes/content/[id]/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/+page.svelte
@@ -41,13 +41,13 @@
     <div class="flex items-center justify-between gap-x-8">
       <a
         href={returnTo}
-        class="rounded-full p-4 transition-colors hover:bg-slate-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+        class="rounded-full p-4 transition-colors hover:bg-slate-200 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
       >
         <ArrowLeft />
       </a>
 
       <button
-        class="cursor-pointer rounded-full p-4 transition-colors hover:bg-slate-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+        class="cursor-pointer rounded-full p-4 transition-colors hover:bg-slate-200 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
       >
         <Share />
       </button>

--- a/apps/learner/src/routes/content/[id]/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/+page.svelte
@@ -39,11 +39,16 @@
 
   <div class="mx-auto w-full max-w-5xl px-4 py-3">
     <div class="flex items-center justify-between gap-x-8">
-      <a href={returnTo} class="rounded-full p-4 transition-colors hover:bg-slate-200">
+      <a
+        href={returnTo}
+        class="rounded-full p-4 transition-colors hover:bg-slate-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+      >
         <ArrowLeft />
       </a>
 
-      <button class="cursor-pointer rounded-full p-4 transition-colors hover:bg-slate-200">
+      <button
+        class="cursor-pointer rounded-full p-4 transition-colors hover:bg-slate-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+      >
         <Share />
       </button>
     </div>

--- a/apps/learner/src/routes/content/[id]/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/+page.svelte
@@ -39,11 +39,11 @@
 
   <div class="mx-auto w-full max-w-5xl px-4 py-3">
     <div class="flex items-center justify-between gap-x-8">
-      <a href={returnTo} class="rounded-full px-3 py-4 transition-colors hover:bg-slate-200">
+      <a href={returnTo} class="rounded-full p-4 transition-colors hover:bg-slate-200">
         <ArrowLeft />
       </a>
 
-      <button class="cursor-pointer rounded-full px-3 py-4 transition-colors hover:bg-slate-200">
+      <button class="cursor-pointer rounded-full p-4 transition-colors hover:bg-slate-200">
         <Share />
       </button>
     </div>


### PR DESCRIPTION
## 🚀 Summary

This PR adds focus effect to the navigation buttons and adjusted their padding from `px-3 py-4` to `p-4`.

## ✏️ Changes

- Added focus effect to the navigation buttons on `Collection` and `LearningUnit` pages
- Update the padding of the navigation buttons from `px-3 py-4` to `p-4` on `Collection` and `LearningUnit` pages