### PR TITLE
feat(learner): move floating player toggle to audio state

### DIFF
--- a/apps/learner/src/lib/helpers/audio-state.svelte.ts
+++ b/apps/learner/src/lib/helpers/audio-state.svelte.ts
@@ -7,6 +7,7 @@ const AUDIO_STATE_KEY = Symbol('AudioState');
  */
 export class AudioState {
   isPlaying = $state(false);
+  isFloatingPlayerVisible = $state(false);
 
   /**
    * Set a new instance of the audio state in the context.

--- a/apps/learner/src/routes/(app)/+page.svelte
+++ b/apps/learner/src/routes/(app)/+page.svelte
@@ -6,7 +6,6 @@
   import LearningUnit from '$lib/components/LearningUnit.svelte';
   import { AudioState } from '$lib/helpers/index.js';
 
-  let isFloatingPlayerVisible = $state(false);
   let isModalOpen = $state(false);
 
   const audioState = AudioState.load();
@@ -16,7 +15,7 @@
   };
 
   const handlePlay = () => {
-    isFloatingPlayerVisible = true;
+    audioState.isFloatingPlayerVisible = true;
     audioState.isPlaying = true;
   };
 
@@ -52,7 +51,7 @@
 <div class="z-100 pointer-events-none fixed inset-x-0 bottom-0">
   <div class="mx-auto max-w-5xl px-4">
     <div class="flex justify-end gap-x-4">
-      {#if isFloatingPlayerVisible}
+      {#if audioState.isFloatingPlayerVisible}
         <div class="pointer-events-auto flex-grow overflow-x-hidden py-3">
           <FloatingPlayer
             title="Navigating Special Educational Needs in Singapore: A Path to Inclusion"


### PR DESCRIPTION
Closes https://github.com/String-sg/onward/issues/142

## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

Moving the floating player toggle to the audio state to centralize the logic related to the player

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Moved the toggle flag to show the floating player