### PR TITLE
feat(learner): update icon for `FloatingChat` component

### DIFF
--- a/apps/learner/src/lib/components/FloatingChat.svelte
+++ b/apps/learner/src/lib/components/FloatingChat.svelte
@@ -1,84 +1,56 @@
 <button
   class="inset-shadow-sm inset-shadow-slate-200 flex items-center rounded-full border border-slate-100 p-5 shadow-lg backdrop-blur-sm"
 >
-  <!-- Icon SVG -->
-  <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" fill="none">
+  <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
     <path
-      d="M18.8222 18.8235C11.545 26.1007 2.82215 29.1765 2.82215 29.1765C2.82215 29.1765 5.89793 20.4536 13.1751 13.1765C20.4523 5.89931 29.1751 2.82353 29.1751 2.82353C29.1751 2.82353 26.0993 11.5464 18.8222 18.8235Z"
-      fill="black"
+      d="M16.0034 6.68726L17.7358 14.2625L25.3345 16.0007H25.3267L17.7358 17.7371L16.0034 25.3123V25.3337L16.0005 25.323L15.9985 25.3337V25.3123L14.2661 17.738L6.67236 16.0007H6.66846L14.2661 14.2625L15.9985 6.68726V6.66675L16.0005 6.67651L16.0034 6.66675V6.68726Z"
+      fill="currentColor"
     />
-    <circle cx="15.9724" cy="15.9724" r="10.6482" fill="black" />
-    <foreignObject x="4.98438" y="4.98291" width="21.9805" height="25.379">
-      <div
-        xmlns="http://www.w3.org/1999/xhtml"
-        style="backdrop-filter:blur(2.5px);clip-path:url(#bgblur_0_1662_16449_clip_path);height:100%;width:100%"
-      ></div>
-    </foreignObject>
-    <g filter="url(#filter0_dii_1662_16449)" data-figma-bg-blur-radius="5">
-      <circle cx="15.974" cy="15.9725" r="5.98961" fill="#FEF4D8" />
-    </g>
-    <path
-      d="M29.1729 2.82324C29.1729 2.82324 26.0973 11.5461 18.8203 18.8232C11.5431 26.1004 2.82031 29.1768 2.82031 29.1768C2.82031 29.1768 3.24823 27.962 4.16309 26.0615C7.36832 24.437 12.0009 21.6515 16.1602 17.4922C20.7223 12.9299 23.633 7.79944 25.1699 4.60645C27.5574 3.39642 29.153 2.83026 29.1729 2.82324Z"
-      fill="black"
+    <ellipse cx="15.9994" cy="2.8485" rx="0.848546" ry="0.848502" fill="currentColor" />
+    <ellipse cx="15.9994" cy="29.152" rx="0.848546" ry="0.848502" fill="currentColor" />
+    <ellipse
+      cx="29.1515"
+      cy="16.0001"
+      rx="0.848502"
+      ry="0.848546"
+      transform="rotate(90 29.1515 16.0001)"
+      fill="currentColor"
     />
-    <defs>
-      <filter
-        id="filter0_dii_1662_16449"
-        x="4.98438"
-        y="4.98291"
-        width="21.9805"
-        height="25.379"
-        filterUnits="userSpaceOnUse"
-        color-interpolation-filters="sRGB"
-      >
-        <feFlood flood-opacity="0" result="BackgroundImageFix" />
-        <feColorMatrix
-          in="SourceAlpha"
-          type="matrix"
-          values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
-          result="hardAlpha"
-        />
-        <feOffset dy="4" />
-        <feGaussianBlur stdDeviation="2.2" />
-        <feComposite in2="hardAlpha" operator="out" />
-        <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.05 0" />
-        <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1662_16449" />
-        <feBlend
-          mode="normal"
-          in="SourceGraphic"
-          in2="effect1_dropShadow_1662_16449"
-          result="shape"
-        />
-        <feColorMatrix
-          in="SourceAlpha"
-          type="matrix"
-          values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
-          result="hardAlpha"
-        />
-        <feOffset dy="4" />
-        <feGaussianBlur stdDeviation="6" />
-        <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
-        <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0" />
-        <feBlend mode="normal" in2="shape" result="effect2_innerShadow_1662_16449" />
-        <feColorMatrix
-          in="SourceAlpha"
-          type="matrix"
-          values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
-          result="hardAlpha"
-        />
-        <feOffset dy="2" />
-        <feGaussianBlur stdDeviation="1" />
-        <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
-        <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.4 0" />
-        <feBlend
-          mode="normal"
-          in2="effect2_innerShadow_1662_16449"
-          result="effect3_innerShadow_1662_16449"
-        />
-      </filter>
-      <clipPath id="bgblur_0_1662_16449_clip_path" transform="translate(-4.98438 -4.98291)">
-        <circle cx="15.974" cy="15.9725" r="5.98961" />
-      </clipPath>
-    </defs>
+    <ellipse
+      cx="2.84872"
+      cy="16.0001"
+      rx="0.848502"
+      ry="0.848546"
+      transform="rotate(90 2.84872 16.0001)"
+      fill="currentColor"
+    />
+    <circle
+      cx="0.848524"
+      cy="0.848524"
+      r="0.848524"
+      transform="matrix(-0.707112 0.707102 -0.707112 -0.707102 26.5024 25.2993)"
+      fill="currentColor"
+    />
+    <circle
+      cx="0.848524"
+      cy="0.848524"
+      r="0.848524"
+      transform="matrix(-0.707112 0.707102 -0.707112 -0.707102 7.90137 6.7002)"
+      fill="currentColor"
+    />
+    <circle
+      cx="0.848524"
+      cy="0.848524"
+      r="0.848524"
+      transform="matrix(-0.707112 -0.707102 0.707111 -0.707102 6.70068 26.5)"
+      fill="currentColor"
+    />
+    <circle
+      cx="0.848524"
+      cy="0.848524"
+      r="0.848524"
+      transform="matrix(-0.707112 -0.707102 0.707111 -0.707102 25.2988 7.90088)"
+      fill="currentColor"
+    />
   </svg>
 </button>


### PR DESCRIPTION
## 🚀 Summary

This PR updates the icon for the `FloatingChat` component.

## ✏️ Changes

- Updated the icon for the `FloatingChat` component

<img width="105" height="86" alt="Screenshot 2025-07-30 at 14 43 52" src="https://github.com/user-attachments/assets/b9093ba4-27d4-4a56-a2b4-4aee665b8378" />
