### PR TITLE
feat(learner): update `FloatingPlayer` and `FloatingChat` components with slightly transparent white background and hover effect

### DIFF
--- a/apps/learner/src/lib/components/FloatingChat.svelte
+++ b/apps/learner/src/lib/components/FloatingChat.svelte
@@ -1,5 +1,5 @@
 <button
-  class="inset-shadow-sm inset-shadow-slate-200 p-5.5 flex cursor-pointer items-center justify-center rounded-full bg-white/30 shadow-sm backdrop-blur-sm transition-all hover:-translate-y-0.5 hover:shadow-md"
+  class="inset-shadow-sm inset-shadow-slate-200 p-5.5 pointer-events-auto flex cursor-pointer items-center justify-center rounded-full bg-white/30 shadow-sm backdrop-blur-sm transition-all hover:-translate-y-0.5 hover:shadow-md"
   aria-label="Open chat"
 >
   <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">

--- a/apps/learner/src/lib/components/FloatingChat.svelte
+++ b/apps/learner/src/lib/components/FloatingChat.svelte
@@ -1,5 +1,5 @@
 <button
-  class="inset-shadow-sm inset-shadow-slate-200 flex items-center rounded-full border border-slate-100 p-5 shadow-lg backdrop-blur-sm"
+  class="inset-shadow-sm inset-shadow-slate-200 flex items-center justify-center rounded-full border border-slate-100 p-5 shadow-lg backdrop-blur-sm"
   aria-label="Open chat"
 >
   <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">

--- a/apps/learner/src/lib/components/FloatingChat.svelte
+++ b/apps/learner/src/lib/components/FloatingChat.svelte
@@ -1,5 +1,5 @@
 <button
-  class="inset-shadow-sm inset-shadow-slate-200 p-5.5 flex cursor-pointer items-center justify-center rounded-full bg-white/30 shadow-sm backdrop-blur-sm"
+  class="inset-shadow-sm inset-shadow-slate-200 p-5.5 flex cursor-pointer items-center justify-center rounded-full bg-white/30 shadow-sm backdrop-blur-sm transition-all hover:-translate-y-0.5 hover:shadow-md"
   aria-label="Open chat"
 >
   <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">

--- a/apps/learner/src/lib/components/FloatingChat.svelte
+++ b/apps/learner/src/lib/components/FloatingChat.svelte
@@ -1,5 +1,5 @@
 <button
-  class="inset-shadow-sm inset-shadow-slate-200 flex items-center justify-center rounded-full border border-slate-100 p-5 shadow-lg backdrop-blur-sm"
+  class="inset-shadow-sm inset-shadow-slate-200 p-5.5 flex items-center justify-center rounded-full border border-slate-100 shadow-lg backdrop-blur-sm"
   aria-label="Open chat"
 >
   <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">

--- a/apps/learner/src/lib/components/FloatingChat.svelte
+++ b/apps/learner/src/lib/components/FloatingChat.svelte
@@ -1,5 +1,5 @@
 <button
-  class="inset-shadow-sm inset-shadow-slate-200 p-5.5 flex cursor-pointer items-center justify-center rounded-full border border-slate-100 bg-white/30 shadow-sm backdrop-blur-sm"
+  class="inset-shadow-sm inset-shadow-slate-200 p-5.5 flex cursor-pointer items-center justify-center rounded-full bg-white/30 shadow-sm backdrop-blur-sm"
   aria-label="Open chat"
 >
   <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">

--- a/apps/learner/src/lib/components/FloatingChat.svelte
+++ b/apps/learner/src/lib/components/FloatingChat.svelte
@@ -1,5 +1,5 @@
 <button
-  class="inset-shadow-sm inset-shadow-slate-200 p-5.5 flex items-center justify-center rounded-full border border-slate-100 shadow-lg backdrop-blur-sm"
+  class="inset-shadow-sm inset-shadow-slate-200 p-5.5 flex cursor-pointer items-center justify-center rounded-full border border-slate-100 shadow-lg backdrop-blur-sm"
   aria-label="Open chat"
 >
   <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">

--- a/apps/learner/src/lib/components/FloatingChat.svelte
+++ b/apps/learner/src/lib/components/FloatingChat.svelte
@@ -1,5 +1,5 @@
 <button
-  class="inset-shadow-sm inset-shadow-slate-200 p-5.5 flex cursor-pointer items-center justify-center rounded-full border border-slate-100 shadow-lg backdrop-blur-sm"
+  class="inset-shadow-sm inset-shadow-slate-200 p-5.5 flex cursor-pointer items-center justify-center rounded-full border border-slate-100 bg-white/30 shadow-sm backdrop-blur-sm"
   aria-label="Open chat"
 >
   <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">

--- a/apps/learner/src/lib/components/FloatingPlayer.svelte
+++ b/apps/learner/src/lib/components/FloatingPlayer.svelte
@@ -35,10 +35,12 @@
   };
 
   const handleKeyDown = (event: KeyboardEvent) => {
-    if (event.key === 'Enter' || event.key === ' ') {
-      // Prevent scrolling for `Space` key.
+    if (event.key === ' ') {
+      // Prevent the default behavior of scrolling.
       event.preventDefault();
+    }
 
+    if (event.key === 'Enter' || event.key === ' ') {
       onclick?.();
     }
   };

--- a/apps/learner/src/lib/components/FloatingPlayer.svelte
+++ b/apps/learner/src/lib/components/FloatingPlayer.svelte
@@ -51,7 +51,7 @@
   tabindex="0"
   onclick={handleClick}
   onkeydown={handleKeyDown}
-  class="inset-shadow-sm inset-shadow-slate-200 grid w-full grid-cols-[auto_1fr_auto] items-center gap-x-3 rounded-full px-3 py-3.5 shadow-lg backdrop-blur-sm"
+  class="inset-shadow-sm inset-shadow-slate-200 grid w-full grid-cols-[auto_1fr_auto] items-center gap-x-3 rounded-full bg-white/30 px-3 py-3.5 shadow-sm backdrop-blur-sm"
 >
   <!-- Temporary image placeholder -->
   <div class="h-12 w-12 rounded-full bg-black"></div>

--- a/apps/learner/src/lib/components/FloatingPlayer.svelte
+++ b/apps/learner/src/lib/components/FloatingPlayer.svelte
@@ -51,7 +51,7 @@
   tabindex="0"
   onclick={handleClick}
   onkeydown={handleKeyDown}
-  class="inset-shadow-sm inset-shadow-slate-200 flex items-center gap-x-3 rounded-full border border-slate-100 p-3 shadow-lg backdrop-blur-sm"
+  class="inset-shadow-sm inset-shadow-slate-200 flex items-center gap-x-3 rounded-full border border-slate-100 px-3 py-3.5 shadow-lg backdrop-blur-sm"
 >
   <!-- Temporary album placeholder -->
   <div class="h-12 w-12 rounded-full bg-black"></div>

--- a/apps/learner/src/lib/components/FloatingPlayer.svelte
+++ b/apps/learner/src/lib/components/FloatingPlayer.svelte
@@ -51,7 +51,7 @@
   tabindex="0"
   onclick={handleClick}
   onkeydown={handleKeyDown}
-  class="inset-shadow-sm inset-shadow-slate-200 grid w-full grid-cols-[auto_1fr_auto] items-center gap-x-3 rounded-full bg-white/30 px-3 py-3.5 shadow-sm backdrop-blur-sm"
+  class="inset-shadow-sm inset-shadow-slate-200 grid w-full grid-cols-[auto_1fr_auto] items-center gap-x-3 rounded-full bg-white/30 px-3 py-3.5 shadow-sm backdrop-blur-sm transition-all hover:-translate-y-0.5 hover:shadow-md"
 >
   <!-- Temporary image placeholder -->
   <div class="h-12 w-12 rounded-full bg-black"></div>

--- a/apps/learner/src/lib/components/FloatingPlayer.svelte
+++ b/apps/learner/src/lib/components/FloatingPlayer.svelte
@@ -51,7 +51,7 @@
   tabindex="0"
   onclick={handleClick}
   onkeydown={handleKeyDown}
-  class="inset-shadow-sm inset-shadow-slate-200 grid w-full grid-cols-[auto_1fr_auto] items-center gap-x-3 rounded-full bg-white/30 px-3 py-3.5 shadow-sm backdrop-blur-sm transition-all hover:-translate-y-0.5 hover:shadow-md"
+  class="inset-shadow-sm inset-shadow-slate-200 grid w-full cursor-pointer grid-cols-[auto_1fr_auto] items-center gap-x-3 rounded-full bg-white/30 px-3 py-3.5 shadow-sm backdrop-blur-sm transition-all hover:-translate-y-0.5 hover:shadow-md"
 >
   <!-- Temporary image placeholder -->
   <div class="h-12 w-12 rounded-full bg-black"></div>

--- a/apps/learner/src/lib/components/FloatingPlayer.svelte
+++ b/apps/learner/src/lib/components/FloatingPlayer.svelte
@@ -51,7 +51,7 @@
   tabindex="0"
   onclick={handleClick}
   onkeydown={handleKeyDown}
-  class="inset-shadow-sm inset-shadow-slate-200 flex items-center gap-x-3 rounded-full border border-slate-100 px-3 py-3.5 shadow-lg backdrop-blur-sm"
+  class="inset-shadow-sm inset-shadow-slate-200 flex items-center gap-x-3 rounded-full px-3 py-3.5 shadow-lg backdrop-blur-sm"
 >
   <!-- Temporary album placeholder -->
   <div class="h-12 w-12 rounded-full bg-black"></div>

--- a/apps/learner/src/lib/components/FloatingPlayer.svelte
+++ b/apps/learner/src/lib/components/FloatingPlayer.svelte
@@ -51,17 +51,17 @@
   tabindex="0"
   onclick={handleClick}
   onkeydown={handleKeyDown}
-  class="inset-shadow-sm inset-shadow-slate-200 flex items-center gap-x-3 rounded-full px-3 py-3.5 shadow-lg backdrop-blur-sm"
+  class="inset-shadow-sm inset-shadow-slate-200 grid w-full grid-cols-[auto_1fr_auto] items-center gap-x-3 rounded-full px-3 py-3.5 shadow-lg backdrop-blur-sm"
 >
-  <!-- Temporary album placeholder -->
+  <!-- Temporary image placeholder -->
   <div class="h-12 w-12 rounded-full bg-black"></div>
 
-  <div class="flex-1 truncate text-sm font-medium">
+  <span class="truncate text-sm font-medium">
     {title}
-  </div>
+  </span>
 
   <button
-    class="flex cursor-pointer items-center rounded-full px-4 py-2 hover:bg-slate-50"
+    class="flex cursor-pointer items-center rounded-full p-2 transition-colors hover:bg-slate-100"
     onclick={handlePlay}
   >
     {#if isplaying}

--- a/apps/learner/src/lib/components/FloatingPlayer.svelte
+++ b/apps/learner/src/lib/components/FloatingPlayer.svelte
@@ -47,11 +47,11 @@
 </script>
 
 <div
-  class="inset-shadow-sm inset-shadow-slate-200 flex items-center gap-x-3 rounded-full border border-slate-100 p-3 shadow-lg backdrop-blur-sm"
-  onclick={handleClick}
   role="button"
   tabindex="0"
+  onclick={handleClick}
   onkeydown={handleKeyDown}
+  class="inset-shadow-sm inset-shadow-slate-200 flex items-center gap-x-3 rounded-full border border-slate-100 p-3 shadow-lg backdrop-blur-sm"
 >
   <!-- Temporary album placeholder -->
   <div class="h-12 w-12 rounded-full bg-black"></div>

--- a/apps/learner/src/lib/components/FloatingPlayer.svelte
+++ b/apps/learner/src/lib/components/FloatingPlayer.svelte
@@ -51,7 +51,7 @@
   tabindex="0"
   onclick={handleClick}
   onkeydown={handleKeyDown}
-  class="inset-shadow-sm inset-shadow-slate-200 grid w-full cursor-pointer grid-cols-[auto_1fr_auto] items-center gap-x-3 rounded-full bg-white/30 px-3 py-3.5 shadow-sm backdrop-blur-sm transition-all hover:-translate-y-0.5 hover:shadow-md"
+  class="inset-shadow-sm inset-shadow-slate-200 pointer-events-auto grid w-full cursor-pointer grid-cols-[auto_1fr_auto] items-center gap-x-3 rounded-full bg-white/30 px-3 py-3.5 shadow-sm backdrop-blur-sm transition-all hover:-translate-y-0.5 hover:shadow-md"
 >
   <!-- Temporary image placeholder -->
   <div class="h-12 w-12 rounded-full bg-black"></div>

--- a/apps/learner/src/routes/(app)/+layout.svelte
+++ b/apps/learner/src/routes/(app)/+layout.svelte
@@ -101,7 +101,7 @@
   </div>
 </header>
 
-<main class="pt-43 relative mx-auto min-h-full w-full max-w-5xl px-4 pb-3">
+<main class="pt-43 pb-25 relative mx-auto min-h-full w-full max-w-5xl px-4">
   <div bind:this={target} class="absolute inset-x-0 top-0 h-px"></div>
 
   {@render children()}

--- a/apps/learner/src/routes/(app)/+page.svelte
+++ b/apps/learner/src/routes/(app)/+page.svelte
@@ -49,21 +49,18 @@
 </div>
 
 <div class="z-100 pointer-events-none fixed inset-x-0 bottom-0">
-  <div class="mx-auto max-w-5xl px-4">
+  <div class="mx-auto max-w-5xl px-4 py-3">
     <div class="flex justify-end gap-x-4">
       {#if audioState.isFloatingPlayerVisible}
-        <div class="pointer-events-auto flex-grow overflow-x-hidden py-3">
-          <FloatingPlayer
-            title="Navigating Special Educational Needs in Singapore: A Path to Inclusion"
-            isplaying={audioState.isPlaying}
-            onplay={togglePlayPause}
-            onclick={handleFloatingPlayerClick}
-          />
-        </div>
+        <FloatingPlayer
+          title="Navigating Special Educational Needs in Singapore: A Path to Inclusion"
+          isplaying={audioState.isPlaying}
+          onplay={togglePlayPause}
+          onclick={handleFloatingPlayerClick}
+        />
       {/if}
-      <div class="pointer-events-auto py-3">
-        <FloatingChat />
-      </div>
+
+      <FloatingChat />
     </div>
   </div>
 </div>


### PR DESCRIPTION
## 🚀 Summary

This PR enhances the `FloatingPlayer` and `FloatingChat` components by adding a slightly transparent white background and a hover effect. It also introduces additional bottom padding to the app layout to accommodate the floating components when scrolled to the bottom.

## ✏️ Changes

- Added `bg-white/30` to `FloatingPlayer` and `FloatingChat` components
- Updated the shadow of `FloatingPlayer` and `FloatingChat` components from `shadow-lg` to `shadow-sm`
- Updated the padding on `FloatingChat` component from `p-5` to `p-5.5`
- Updated the padding on `FloatingPlayer` component from `p-3` to `px-3 py-3.5`
- Added hover effect for `FloatingPlayer` and `FloatingChat` components
- Added additional bottom padding to the app layout to accommodate the floating components
