### PR TITLE
feat(learner): full page chat modal

### DIFF
--- a/apps/learner/src/lib/components/Badge/Badge.svelte
+++ b/apps/learner/src/lib/components/Badge/Badge.svelte
@@ -3,7 +3,7 @@
   import type { HTMLAttributes } from 'svelte/elements';
 
   export interface Props extends HTMLAttributes<HTMLDivElement> {
-    variant: 'blue' | 'orange' | 'amber' | 'teal' | 'rose' | 'purple' | 'slate';
+    variant: 'blue' | 'orange' | 'amber' | 'teal' | 'rose' | 'purple' | 'slate' | 'darkSlate';
     children: Snippet;
   }
 
@@ -21,6 +21,7 @@
     variant === 'rose' && 'bg-rose-200 text-rose-900',
     variant === 'purple' && 'bg-purple-200 text-purple-900',
     variant === 'slate' && 'bg-slate-200 text-slate-950',
+    variant === 'darkSlate' && 'bg-slate-950 text-white',
     clazz,
   ]}
 >

--- a/apps/learner/src/lib/components/ChatModal/ChatModal.svelte
+++ b/apps/learner/src/lib/components/ChatModal/ChatModal.svelte
@@ -1,0 +1,231 @@
+<script lang="ts">
+  import { ArrowLeft, SendHorizontal } from '@lucide/svelte';
+  import { onDestroy, onMount } from 'svelte';
+  import type { MouseEventHandler } from 'svelte/elements';
+  import { fade, fly } from 'svelte/transition';
+
+  import { Badge } from '$lib/components/Badge/index.js';
+  import { useIsWithinViewport } from '$lib/helpers/index.js';
+
+  interface ChatMessage {
+    role: 'user' | 'assistant';
+    content: string;
+  }
+
+  export interface Props {
+    /**
+     * A callback function that is called when the user clicks on the Back button.
+     */
+    onclose?: MouseEventHandler<HTMLButtonElement>;
+  }
+
+  const { onclose }: Props = $props();
+
+  let target = $state<HTMLElement | null>(null);
+  let userPrompt = $state('');
+  let convo = $state<ChatMessage[]>([]);
+  let isAiTyping = $state(false);
+
+  let isTypingPrompt = $derived(userPrompt.trim());
+
+  let textareaElement: HTMLTextAreaElement;
+  const isWithinViewport = useIsWithinViewport(() => target);
+
+  const recommendedPrompt = [
+    'What are three quick strategies for teaching reading to a student with dyslexia in a mainstream classroom?',
+    'How can I create a sensory-friendly classroom for students with autism spectrum disorder?',
+  ];
+
+  // Disable scrolling when component mounts
+  onMount(() => {
+    disableScroll();
+  });
+
+  // Re-enable scrolling when component is destroyed
+  onDestroy(() => {
+    enableScroll();
+  });
+
+  const disableScroll = () => {
+    document.body.style.overflow = 'hidden';
+    document.body.style.touchAction = 'none'; // For mobile devices
+  };
+
+  const enableScroll = () => {
+    document.body.style.overflow = '';
+    document.body.style.touchAction = '';
+  };
+
+  const handleSendPrompt = () => {
+    if (!userPrompt.trim()) return;
+
+    convo = [...convo, { role: 'user', content: userPrompt }];
+    userPrompt = '';
+
+    // Set AI typing state to true
+    isAiTyping = true;
+
+    setTimeout(() => {
+      convo = [
+        ...convo,
+        {
+          role: 'assistant',
+          content: 'Chat is currently under development, please try again later.',
+        },
+      ];
+      isAiTyping = false;
+    }, 3000);
+  };
+
+  const autoResizeTextarea = (maxrows = 4) => {
+    if (!textareaElement) return;
+
+    textareaElement.style.height = 'auto';
+    const lineHeight = parseFloat(getComputedStyle(textareaElement).lineHeight); // Get actual line height
+    const maxHeight = lineHeight * maxrows;
+
+    if (!userPrompt || userPrompt.trim() === '') {
+      textareaElement.style.height = '';
+    } else {
+      textareaElement.style.height = `${Math.min(textareaElement.scrollHeight, maxHeight)}px`;
+    }
+  };
+
+  const handleRecommendedPrompt = (prompt: string) => {
+    userPrompt = prompt;
+    handleSendPrompt();
+    autoResizeTextarea();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      // Prevent default behavior of going to a new line within textarea
+      event.preventDefault();
+      handleSendPrompt();
+    }
+  };
+
+  const handleClear = () => {
+    convo = [];
+  };
+
+  const handleInput = () => {
+    autoResizeTextarea();
+  };
+</script>
+
+<!-- Backdrop -->
+<div transition:fade={{ duration: 300 }} class="z-199 fixed inset-0 bg-slate-950/50"></div>
+
+<!-- Modal -->
+<div
+  class="z-200 fixed inset-0 bg-slate-100"
+  transition:fly={{ duration: 300, y: '100%', opacity: 1 }}
+>
+  <header class="inset-x-0 top-0 flex backdrop-blur-sm">
+    <div
+      class={[
+        'absolute inset-x-0 top-full h-px bg-transparent transition-colors duration-300',
+        !isWithinViewport.current && '!bg-slate-950/7.5',
+      ]}
+    ></div>
+
+    <div class="mx-auto flex w-full max-w-5xl items-center justify-between px-4 py-3">
+      <div class="flex items-center gap-x-2">
+        <button
+          onclick={onclose}
+          class="rounded-full p-4 transition-colors hover:bg-slate-200 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+        >
+          <ArrowLeft />
+        </button>
+
+        <Badge variant="darkSlate">Ask AI</Badge>
+      </div>
+
+      {#if convo.length > 0}
+        <button
+          onclick={handleClear}
+          class="cursor-pointer rounded-full p-4 font-bold transition-colors hover:bg-slate-50 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+        >
+          Clear
+        </button>
+      {/if}
+    </div>
+  </header>
+
+  <main class="pb-23 relative mx-auto min-h-full w-full max-w-5xl px-4 pt-3">
+    <div bind:this={target} class="absolute inset-x-0 top-0 h-px"></div>
+
+    <!-- TODO: temporary hardcode height for now. To relook at how to set this height without hardcoding an arbitrary height -->
+    <div class="h-[calc(100vh-180px)] overflow-y-auto">
+      <div class="flex flex-col gap-y-4 px-1">
+        {#if convo.length === 0}
+          <span class="text-xl font-medium">
+            Hi Mr. Tan, here are some of the example questions relevant to Special Educational Needs
+            topic.
+          </span>
+        {/if}
+
+        <div class="flex flex-col gap-y-2.5">
+          {#if convo.length === 0}
+            {#each recommendedPrompt as prompt, index (index)}
+              <button
+                class="cursor-pointer rounded-3xl bg-white p-4 text-left hover:bg-slate-50 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+                onclick={() => handleRecommendedPrompt(prompt)}
+              >
+                {prompt}
+              </button>
+            {/each}
+          {:else}
+            {#each convo as { role, content }, index (index)}
+              <div class={['flex flex-col', role === 'user' && 'items-end']}>
+                <span
+                  class={['rounded-3xl p-4 text-left', role === 'user' && 'max-w-4/5 bg-white']}
+                >
+                  {content}
+                </span>
+              </div>
+            {/each}
+
+            {#if isAiTyping}
+              <span class="rounded-3xl p-4 text-left">AI is typing...</span>
+            {/if}
+          {/if}
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <div class="fixed inset-x-0 bottom-0">
+    <div class="mx-auto w-full max-w-5xl px-4 py-3">
+      <div
+        class={[
+          'inset-shadow-sm inset-shadow-slate-200 rounded-4xl pointer-events-auto flex items-center gap-x-3 border border-slate-100 bg-white/30 p-3 shadow-lg backdrop-blur-sm',
+          !isAiTyping &&
+            'transition-all hover:-translate-y-0.5 hover:border-slate-300 hover:shadow-md',
+        ]}
+      >
+        <textarea
+          bind:value={userPrompt}
+          bind:this={textareaElement}
+          name="prompt"
+          class="w-full resize-none items-center p-3 outline-0"
+          placeholder="Ask AI about SEN"
+          onkeydown={handleKeyDown}
+          oninput={handleInput}
+          rows="1"
+          disabled={isAiTyping}
+        >
+        </textarea>
+
+        <button
+          class="cursor-pointer rounded-full bg-slate-950 p-4 text-white transition-colors hover:bg-slate-900/70 disabled:pointer-events-none disabled:bg-slate-900/50"
+          disabled={!isTypingPrompt || isAiTyping}
+          onclick={handleSendPrompt}
+        >
+          <SendHorizontal />
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/apps/learner/src/lib/components/ChatModal/index.ts
+++ b/apps/learner/src/lib/components/ChatModal/index.ts
@@ -1,0 +1,1 @@
+export { default as ChatModal, type Props as ChatModalProps } from './ChatModal.svelte';

--- a/apps/learner/src/lib/components/FloatingChat/FloatingChat.svelte
+++ b/apps/learner/src/lib/components/FloatingChat/FloatingChat.svelte
@@ -1,6 +1,20 @@
+<script lang="ts">
+  import type { MouseEventHandler } from 'svelte/elements';
+
+  export interface Props {
+    /**
+     * A callback function that is called when the user clicks on the chat button.
+     */
+    onclick?: MouseEventHandler<HTMLButtonElement>;
+  }
+
+  let { onclick }: Props = $props();
+</script>
+
 <button
   class="inset-shadow-sm inset-shadow-slate-200 p-5.5 pointer-events-auto flex cursor-pointer items-center justify-center rounded-full bg-white/30 shadow-sm backdrop-blur-sm transition-all hover:-translate-y-0.5 hover:shadow-md"
   aria-label="Open chat"
+  {onclick}
 >
   <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
     <path

--- a/apps/learner/src/lib/components/FloatingChat/index.ts
+++ b/apps/learner/src/lib/components/FloatingChat/index.ts
@@ -1,0 +1,1 @@
+export { default as FloatingChat, type Props as FloatingChatProps } from './FloatingChat.svelte';

--- a/apps/learner/src/routes/(app)/+page.svelte
+++ b/apps/learner/src/routes/(app)/+page.svelte
@@ -3,18 +3,20 @@
   import { fade, fly } from 'svelte/transition';
 
   import Badge from '$lib/components/Badge/Badge.svelte';
-  import FloatingChat from '$lib/components/FloatingChat.svelte';
+  import { ChatModal } from '$lib/components/ChatModal/index.js';
+  import { FloatingChat } from '$lib/components/FloatingChat/index.js';
   import FloatingPlayer from '$lib/components/FloatingPlayer.svelte';
   import LearningUnit from '$lib/components/LearningUnit.svelte';
   import { Portal } from '$lib/components/Portal/index.js';
   import { AudioState } from '$lib/helpers/index.js';
 
-  let isModalOpen = $state(false);
+  let isPlayerModalOpen = $state(false);
+  let isChatModalOpen = $state(false);
 
   const audioState = AudioState.load();
 
   const handleFloatingPlayerClick = () => {
-    isModalOpen = !isModalOpen;
+    isPlayerModalOpen = !isPlayerModalOpen;
   };
 
   const handlePlay = () => {
@@ -24,6 +26,14 @@
 
   const togglePlayPause = () => {
     audioState.isPlaying = !audioState.isPlaying;
+  };
+
+  const openChatModal = () => {
+    isChatModalOpen = true;
+  };
+
+  const closeChatModal = () => {
+    isChatModalOpen = false;
   };
 </script>
 
@@ -63,13 +73,13 @@
         />
       {/if}
 
-      <FloatingChat />
+      <FloatingChat onclick={openChatModal} />
     </div>
   </div>
 </div>
 
 <Portal>
-  {#if isModalOpen}
+  {#if isPlayerModalOpen}
     <!-- Backdrop -->
     <div transition:fade={{ duration: 300 }} class="z-199 fixed inset-0 bg-slate-950/50"></div>
 
@@ -169,5 +179,9 @@
         </div>
       </div>
     </div>
+  {/if}
+
+  {#if isChatModalOpen}
+    <ChatModal onclose={closeChatModal} />
   {/if}
 </Portal>


### PR DESCRIPTION
Closes #122 

## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->
This PR adds the full page chat modal when user clicks on the floating chat. This allows user to interact with the AI chat to find out more about the learning units that they want to find out more about.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->
- Added new `ChatModal` component that contains all the features within the chat itself
- Added a new `darkSlate` variant on the `Badge` component 
- Renamed `isModalOpen` to `isPlayerModalOpen` to have better clarity on which modal is opened

## 🗒️  Notes
- This PR only targets the UI interfaces and interactions. 
- Data has been hardcoded since backend has yet to be integrated. 
- Certain behaviours are mocked to get a sense of the behaviour of the chat 