### PR TITLE
fix: enable `svelte-check` to fail on warnings in CI

### DIFF
--- a/apps/creator/package.json
+++ b/apps/creator/package.json
@@ -7,7 +7,7 @@
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
-    "check": "svelte-kit sync && svelte-check",
+    "check": "svelte-kit sync && svelte-check --fail-on-warnings",
     "prepare": "svelte-kit sync || echo ''"
   },
   "devDependencies": {

--- a/apps/learner/package.json
+++ b/apps/learner/package.json
@@ -7,7 +7,7 @@
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
-    "check": "svelte-kit sync && svelte-check",
+    "check": "svelte-kit sync && svelte-check --fail-on-warnings",
     "prepare": "svelte-kit sync || echo ''"
   },
   "dependencies": {

--- a/apps/learner/src/lib/components/FloatingChat.svelte
+++ b/apps/learner/src/lib/components/FloatingChat.svelte
@@ -1,5 +1,6 @@
 <button
   class="inset-shadow-sm inset-shadow-slate-200 flex items-center rounded-full border border-slate-100 p-5 shadow-lg backdrop-blur-sm"
+  aria-label="Open chat"
 >
   <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
     <path


### PR DESCRIPTION
## 🚀 Summary

By default `svelte-check` does not return a non-zero exit code on warnings. This PR adds the `--fail-on-warnings` flag to all `svelte-check` commands so that warnings will cause a non-zero exit code, allowing the CI to fail.

## ✏️ Changes

- Added `--fail-on-warnings` flag to `svelte-check` in learner and creator apps
- Added `aria-label` to `FloatingChat` component