### PR TITLE
chore: enable ESLint validation for `.js` and `.ts` files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,8 @@
   // Enables TypeScript support in `.svelte` files.
   "svelte.enable-ts-plugin": true,
 
-  // Shows ESLint errors/warnings in `.svelte` files.
-  "eslint.validate": ["svelte"],
+  // Shows ESLint errors/warnings in `.js`, `.ts`, and `.svelte` files.
+  "eslint.validate": ["javascript", "typescript", "svelte"],
 
   "[svelte]": {
     "editor.defaultFormatter": "svelte.svelte-vscode"


### PR DESCRIPTION
## 🚀 Summary

Previously, only `.svelte` files displayed ESLint errors and warnings. This PR adds `javascript` and `typescript` to `eslint.validate` field so that `.js` and `.ts` files are also validated.

## ✏️ Changes

- Added `javascript` and `typescript` to `eslint.validate` field
