### PR TITLE
chore(learner): switch `@lucide/svelte` imports to direct icon paths

### DIFF
--- a/apps/learner/src/lib/components/FloatingPlayer.svelte
+++ b/apps/learner/src/lib/components/FloatingPlayer.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Pause, Play } from '@lucide/svelte';
+  import Pause from '@lucide/svelte/icons/pause';
+  import Play from '@lucide/svelte/icons/play';
   import type { MouseEventHandler } from 'svelte/elements';
 
   interface Props {

--- a/apps/learner/src/lib/components/LearningUnit.svelte
+++ b/apps/learner/src/lib/components/LearningUnit.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Play } from '@lucide/svelte';
+  import Play from '@lucide/svelte/icons/play';
   import type { MouseEventHandler } from 'svelte/elements';
 
   import { Badge, type BadgeProps } from '$lib/components/Badge/index.js';

--- a/apps/learner/src/routes/(app)/+layout.svelte
+++ b/apps/learner/src/routes/(app)/+layout.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-  import { BookHeart, Compass, Home } from '@lucide/svelte';
+  import BookHeart from '@lucide/svelte/icons/book-heart';
+  import Compass from '@lucide/svelte/icons/compass';
+  import Home from '@lucide/svelte/icons/home';
 
   import { page } from '$app/state';
   import { useIsWithinViewport } from '$lib/helpers';

--- a/apps/learner/src/routes/(app)/+page.svelte
+++ b/apps/learner/src/routes/(app)/+page.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import { ArrowLeft, Pause, RotateCcw, RotateCw, SkipBack, SkipForward } from '@lucide/svelte';
+  import ArrowLeft from '@lucide/svelte/icons/arrow-left';
+  import Pause from '@lucide/svelte/icons/pause';
+  import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
+  import RotateCw from '@lucide/svelte/icons/rotate-cw';
+  import SkipBack from '@lucide/svelte/icons/skip-back';
+  import SkipForward from '@lucide/svelte/icons/skip-forward';
   import { fade, fly } from 'svelte/transition';
 
   import Badge from '$lib/components/Badge/Badge.svelte';

--- a/apps/learner/src/routes/collection/[id]/+page.svelte
+++ b/apps/learner/src/routes/collection/[id]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ArrowLeft } from '@lucide/svelte';
+  import ArrowLeft from '@lucide/svelte/icons/arrow-left';
 
   import LearningUnit from '$lib/components/LearningUnit.svelte';
   import { useIsWithinViewport } from '$lib/helpers';

--- a/apps/learner/src/routes/content/[id]/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/+page.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-  import { ArrowLeft, ChevronsDown, Lightbulb, Play, Share } from '@lucide/svelte';
+  import ArrowLeft from '@lucide/svelte/icons/arrow-left';
+  import ChevronsDown from '@lucide/svelte/icons/chevrons-down';
+  import Lightbulb from '@lucide/svelte/icons/lightbulb';
+  import Play from '@lucide/svelte/icons/play';
+  import Share from '@lucide/svelte/icons/share';
   import { formatDistanceToNow } from 'date-fns';
 
   import { afterNavigate } from '$app/navigation';

--- a/apps/learner/src/routes/content/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/quiz/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { ArrowLeft, X } from '@lucide/svelte';
+  import ArrowLeft from '@lucide/svelte/icons/arrow-left';
+  import X from '@lucide/svelte/icons/x';
   import { slide } from 'svelte/transition';
 
   import { base } from '$app/paths';


### PR DESCRIPTION
## 🚀 Summary

This PR switches imports from `@lucide/svelte` to direct icon paths. 

## ✏️ Changes

- Switched `@lucide/svelte` imports to direct icon paths
