### PR TITLE
feat(learner): add custom scrollbar styling

### DIFF
--- a/apps/learner/src/app.css
+++ b/apps/learner/src/app.css
@@ -1,6 +1,12 @@
 @import url('https://fonts.googleapis.com/css2?family=Geist:wght@100..900&display=swap');
 @import 'tailwindcss';
 
+@layer base {
+  * {
+    scrollbar-color: color-mix(in oklab, var(--color-slate-950) 20%, transparent) transparent;
+  }
+}
+
 @theme {
   --font-geist: 'Geist', sans-serif;
 }


### PR DESCRIPTION
## 🚀 Summary

This PR adds custom scrollbar styling to ensure it integrates seamlessly with the existing colour palette.

## ✏️ Changes

- Added custom scrollbar styling using `slate-950` at 20% opacity with a transparent background