### PR TITLE
feat(learner): sync player state on learning content

### DIFF
--- a/apps/learner/src/lib/states/player.svelte.ts
+++ b/apps/learner/src/lib/states/player.svelte.ts
@@ -3,7 +3,7 @@ import { getContext, setContext } from 'svelte';
 const PLAYER_CONTEXT_KEY = Symbol('Player');
 
 export interface Track {
-  id: string;
+  id: number;
   title: string;
 }
 
@@ -21,7 +21,7 @@ export interface Track {
  * const player = Player.create();
  *
  * // Play a track.
- * player.play({ id: '1', title: 'My Track' });
+ * player.play({ id: 1, title: 'My Track' });
  *
  * // Toggle playback.
  * player.toggle();
@@ -30,7 +30,7 @@ export interface Track {
  * console.log(player.isPlaying); // true or false
  *
  * // Get current track.
- * console.log(player.currentTrack); // { id: '1', title: 'My Track' } or null
+ * console.log(player.currentTrack); // { id: 1, title: 'My Track' } or null
  * ```
  */
 export class Player {

--- a/apps/learner/src/routes/(app)/+page.server.ts
+++ b/apps/learner/src/routes/(app)/+page.server.ts
@@ -4,15 +4,15 @@ export const load: PageServerLoad = async () => {
   return {
     learningUnits: [
       {
-        id: '1',
+        id: 1,
         title: 'Navigating Special Education Needs in Singapore: A Path to Inclusion',
       },
       {
-        id: '2',
+        id: 2,
         title: 'Testing the Waters: A Guide to Special Educational Needs in Singapore',
       },
       {
-        id: '3',
+        id: 3,
         title: 'The quick brown fox jumps over the lazy dog',
       },
     ],

--- a/apps/learner/src/routes/content/[id]/+page.server.ts
+++ b/apps/learner/src/routes/content/[id]/+page.server.ts
@@ -2,7 +2,7 @@ import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
   return {
-    id: 1,
+    id: '1',
     tags: ['Special Educational Needs'],
     title: 'Navigating Special Educational Needs: A Path to Inclusion',
     summary:

--- a/apps/learner/src/routes/content/[id]/+page.server.ts
+++ b/apps/learner/src/routes/content/[id]/+page.server.ts
@@ -2,7 +2,7 @@ import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
   return {
-    id: '1',
+    id: 1,
     tags: ['Special Educational Needs'],
     title: 'Navigating Special Educational Needs: A Path to Inclusion',
     summary:

--- a/apps/learner/src/routes/content/[id]/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/+page.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-  import { ArrowLeft, ChevronsDown, Lightbulb, Play, Share } from '@lucide/svelte';
+  import { ArrowLeft, ChevronsDown, Lightbulb, Pause, Play, Share } from '@lucide/svelte';
   import { formatDistanceToNow } from 'date-fns';
 
   import { afterNavigate } from '$app/navigation';
   import { Badge } from '$lib/components/Badge/index.js';
   import { Button, LinkButton } from '$lib/components/Button/index.js';
   import { IsWithinViewport } from '$lib/helpers/index.js';
+  import { Player, type Track } from '$lib/states/index.js';
 
   const { data } = $props();
 
@@ -14,6 +15,9 @@
   let target = $state<HTMLElement | null>(null);
 
   const isWithinViewport = new IsWithinViewport(() => target);
+  const player = Player.get();
+
+  let isActive = $derived(player.currentTrack?.id === data.id);
 
   afterNavigate(({ from, type }) => {
     if (type === 'enter' || !from) {
@@ -26,6 +30,22 @@
 
   const toggleIsExpanded = () => {
     isExpanded = !isExpanded;
+  };
+
+  // TODO: Change to LearningUnit type once it is added
+  const handlePlay = (learningUnit: Track) => {
+    player.play({
+      id: learningUnit.id,
+      title: learningUnit.title,
+    });
+  };
+
+  const handlePause = () => {
+    player.toggle();
+  };
+
+  const handleResume = () => {
+    player.toggle();
   };
 </script>
 
@@ -82,10 +102,26 @@
         </div>
 
         <div class="flex flex-col gap-y-4">
-          <Button width="full">
-            <Play class="h-4 w-4" />
-            <span class="font-medium">Play</span>
-          </Button>
+          {#if isActive && player.isPlaying}
+            <Button variant="primary" width="full" onclick={handlePause}>
+              <Pause class="h-4 w-4" />
+              <span class="font-medium">Pause</span>
+            </Button>
+          {:else if isActive && !player.isPlaying}
+            <Button variant="primary" width="full" onclick={handleResume}>
+              <Play class="h-4 w-4" />
+              <span class="font-medium">Resume</span>
+            </Button>
+          {:else}
+            <Button
+              variant="primary"
+              width="full"
+              onclick={() => handlePlay({ id: data.id, title: data.title })}
+            >
+              <Play class="h-4 w-4" />
+              <span class="font-medium">Play</span>
+            </Button>
+          {/if}
 
           <LinkButton variant="secondary" width="full" href={`/content/${data.id}/quiz`}>
             <Lightbulb class="h-4 w-4" />


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->
This PR applies the **Player State** on Learning Content to synchronize the player button UI.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->
- Added Player event handlers for the Learning Content button UI
- Added Play, Pause, and Resume button UI.
- Change `Track` interface `id` to a number to align with LearningUnit data type