### PR TITLE
feat(learner): add `Modal` and `NowPlayingView` component

### DIFF
--- a/apps/learner/src/lib/components/Modal/Modal.svelte
+++ b/apps/learner/src/lib/components/Modal/Modal.svelte
@@ -1,0 +1,119 @@
+<script lang="ts">
+  import type { HTMLAttributes, PointerEventHandler } from 'svelte/elements';
+  import { fade, fly } from 'svelte/transition';
+
+  import { Portal } from '$lib/components/Portal/index.js';
+
+  export interface Props extends HTMLAttributes<HTMLDivElement> {
+    /**
+     * Indicates the visibility of the modal.
+     */
+    isvisible: boolean;
+    /**
+     * A callback invoked when the modal is closed.
+     */
+    onclose: () => void;
+    /**
+     * The variant of the modal.
+     *
+     * @default 'light'
+     */
+    variant?: 'light' | 'dark';
+    /**
+     * The size of the modal.
+     *
+     * @default 'full'
+     */
+    size?: 'full' | 'partial';
+    /**
+     * Indicates whether the modal should be closed when the escape key is pressed.
+     *
+     * @default true
+     */
+    closeonescape?: boolean;
+    /**
+     * Indicates whether the modal should be closed when the backdrop is clicked.
+     *
+     * @default true
+     */
+    closeonbackdropclick?: boolean;
+  }
+
+  const {
+    isvisible,
+    onclose,
+    variant = 'light',
+    size = 'full',
+    closeonescape = true,
+    closeonbackdropclick = true,
+    class: clazz,
+    children,
+    ...otherProps
+  }: Props = $props();
+
+  $effect.pre(() => {
+    const prev = document.body.style.getPropertyValue('overflow');
+
+    if (isvisible) {
+      document.body.style.setProperty('overflow', 'hidden');
+    }
+
+    return () => {
+      document.body.style.setProperty('overflow', prev);
+    };
+  });
+
+  $effect(() => {
+    if (!closeonescape || !isvisible) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') {
+        return;
+      }
+
+      onclose();
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  });
+
+  const handleBackdropClick: PointerEventHandler<HTMLDivElement> = () => {
+    if (!closeonbackdropclick) {
+      return;
+    }
+
+    onclose();
+  };
+</script>
+
+<Portal>
+  {#if isvisible}
+    <!-- Backdrop -->
+    <div
+      transition:fade={{ duration: 300 }}
+      onpointerdown={handleBackdropClick}
+      class="z-200 fixed inset-0 bg-slate-950/50"
+    ></div>
+
+    <div
+      transition:fly={{ duration: 300, y: '100%', opacity: 1 }}
+      class={[
+        'z-201 fixed size-full overflow-y-auto',
+        variant === 'light' && 'bg-white',
+        variant === 'dark' && 'bg-slate-950 text-white',
+        size === 'full' && 'inset-0',
+        size === 'partial' && 'inset-x-0 top-1/4',
+        clazz,
+      ]}
+      {...otherProps}
+    >
+      {@render children?.()}
+    </div>
+  {/if}
+</Portal>

--- a/apps/learner/src/lib/components/Modal/index.ts
+++ b/apps/learner/src/lib/components/Modal/index.ts
@@ -1,0 +1,1 @@
+export { default as Modal, type Props as ModalProps } from './Modal.svelte';

--- a/apps/learner/src/lib/components/NowPlayingView/NowPlayingView.svelte
+++ b/apps/learner/src/lib/components/NowPlayingView/NowPlayingView.svelte
@@ -79,35 +79,35 @@
         <div class="flex justify-between py-4">
           <!-- Backward Button -->
           <button
-            class="cursor-pointer rounded-full p-3 transition-colors hover:bg-white/20 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+            class="cursor-pointer rounded-full p-3 transition-colors hover:bg-white/20 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white sm:p-4"
           >
             <SkipBack />
           </button>
 
           <!-- Replay Button -->
           <button
-            class="cursor-pointer rounded-full p-3 transition-colors hover:bg-white/20 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+            class="cursor-pointer rounded-full p-3 transition-colors hover:bg-white/20 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white sm:p-4"
           >
             <RotateCcw />
           </button>
 
           <!-- Play/Pause Button -->
           <button
-            class="cursor-pointer rounded-full bg-white p-3 text-black transition-colors hover:bg-white/75 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+            class="cursor-pointer rounded-full bg-white p-3 text-black transition-colors hover:bg-white/75 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white sm:p-4"
           >
             <Pause />
           </button>
 
           <!-- Forward Button -->
           <button
-            class="cursor-pointer rounded-full p-3 transition-colors hover:bg-white/20 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+            class="cursor-pointer rounded-full p-3 transition-colors hover:bg-white/20 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white sm:p-4"
           >
             <RotateCw />
           </button>
 
           <!-- Next Button -->
           <button
-            class="cursor-pointer rounded-full p-3 transition-colors hover:bg-white/20 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+            class="cursor-pointer rounded-full p-3 transition-colors hover:bg-white/20 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white sm:p-4"
           >
             <SkipForward />
           </button>

--- a/apps/learner/src/lib/components/NowPlayingView/NowPlayingView.svelte
+++ b/apps/learner/src/lib/components/NowPlayingView/NowPlayingView.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+  import { ChevronDown, Pause, RotateCcw, RotateCw, SkipBack, SkipForward } from '@lucide/svelte';
+  import type { MouseEventHandler } from 'svelte/elements';
+
+  import { Badge } from '$lib/components/Badge/index.js';
+  import { Modal, type ModalProps } from '$lib/components/Modal/index.js';
+
+  export interface Props {
+    /**
+     * Indicates the visibility of the view.
+     */
+    isvisible: ModalProps['isvisible'];
+    /**
+     * A callback invoked when the view is closed.
+     */
+    onclose: ModalProps['onclose'];
+  }
+
+  const { isvisible, onclose }: Props = $props();
+
+  const handleClose: MouseEventHandler<HTMLButtonElement> = () => {
+    onclose();
+  };
+</script>
+
+<Modal {isvisible} {onclose} variant="dark">
+  <div class="mx-auto flex size-full max-w-5xl flex-col gap-y-4 px-4 py-3">
+    <!-- Navigation -->
+    <div class="flex items-center">
+      <button
+        class="cursor-pointer rounded-full p-4 transition-colors hover:bg-white/20 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+        onclick={handleClose}
+      >
+        <ChevronDown />
+      </button>
+    </div>
+
+    <div class="flex-1"></div>
+
+    <div class="flex flex-col gap-y-6">
+      <!-- Badge and Title -->
+      <div class="flex flex-col gap-y-3">
+        <Badge variant="purple">Special Educational Needs</Badge>
+
+        <a
+          href="/content/1"
+          class="w-fit text-xl focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+        >
+          Navigating Special Educational Needs: A Path to Inclusion
+        </a>
+      </div>
+
+      <div class="flex flex-col gap-y-5">
+        <!-- Slider and Timestamp -->
+        <div class="flex flex-col gap-y-2">
+          <div class="group relative h-2 rounded-full bg-slate-700">
+            <div class="h-full w-3/4 rounded-full bg-white"></div>
+            <div
+              class="absolute left-3/4 top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-white opacity-0 transition-opacity group-hover:opacity-100"
+            ></div>
+          </div>
+
+          <div class="flex justify-between">
+            <span>14:32</span>
+            <span>-2.00</span>
+          </div>
+        </div>
+
+        <!-- Speed Control -->
+        <div class="flex justify-center">
+          <button
+            class="flex cursor-pointer items-center rounded-full bg-white/20 px-4 py-2 transition-colors hover:bg-white/30 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+          >
+            <span class="text-sm font-medium">1.0x speed</span>
+          </button>
+        </div>
+
+        <!-- Playback Controls -->
+        <div class="flex justify-between py-4">
+          <!-- Backward Button -->
+          <button
+            class="cursor-pointer rounded-full p-3 transition-colors hover:bg-white/20 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+          >
+            <SkipBack />
+          </button>
+
+          <!-- Replay Button -->
+          <button
+            class="cursor-pointer rounded-full p-3 transition-colors hover:bg-white/20 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+          >
+            <RotateCcw />
+          </button>
+
+          <!-- Play/Pause Button -->
+          <button
+            class="cursor-pointer rounded-full bg-white p-3 text-black transition-colors hover:bg-white/75 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+          >
+            <Pause />
+          </button>
+
+          <!-- Forward Button -->
+          <button
+            class="cursor-pointer rounded-full p-3 transition-colors hover:bg-white/20 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+          >
+            <RotateCw />
+          </button>
+
+          <!-- Next Button -->
+          <button
+            class="cursor-pointer rounded-full p-3 transition-colors hover:bg-white/20 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+          >
+            <SkipForward />
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</Modal>

--- a/apps/learner/src/lib/components/NowPlayingView/index.ts
+++ b/apps/learner/src/lib/components/NowPlayingView/index.ts
@@ -1,0 +1,4 @@
+export {
+  default as NowPlayingView,
+  type Props as NowPlayingViewProps,
+} from './NowPlayingView.svelte';

--- a/apps/learner/src/routes/+layout.svelte
+++ b/apps/learner/src/routes/+layout.svelte
@@ -1,13 +1,9 @@
 <script lang="ts">
   import '../app.css';
 
-  import { ArrowLeft, Pause, RotateCcw, RotateCw, SkipBack, SkipForward } from '@lucide/svelte';
-  import { fade, fly } from 'svelte/transition';
-
-  import { Badge } from '$lib/components/Badge/index.js';
   import { ChatWidget } from '$lib/components/ChatWidget/index.js';
   import { NowPlayingBar } from '$lib/components/NowPlayingBar/index.js';
-  import { Portal } from '$lib/components/Portal/index.js';
+  import { NowPlayingView } from '$lib/components/NowPlayingView/index.js';
   import { Player } from '$lib/states/index.js';
 
   const { children } = $props();
@@ -32,122 +28,18 @@
 {@render children()}
 
 <div class="z-100 pointer-events-none fixed inset-x-0 bottom-0">
-  <div class="mx-auto max-w-5xl px-4 py-3">
-    <div class="flex justify-end gap-x-4">
-      {#if player.currentTrack}
-        <NowPlayingBar
-          title={player.currentTrack.title}
-          isplaying={player.isPlaying}
-          onclick={handleNowPlayingBarClick}
-          onplay={handleNowPlayingBarPlay}
-        />
-      {/if}
+  <div class="mx-auto flex max-w-5xl justify-end gap-x-4 px-4 py-3">
+    {#if player.currentTrack}
+      <NowPlayingBar
+        title={player.currentTrack.title}
+        isplaying={player.isPlaying}
+        onclick={handleNowPlayingBarClick}
+        onplay={handleNowPlayingBarPlay}
+      />
+    {/if}
 
-      <ChatWidget />
-    </div>
+    <ChatWidget />
   </div>
 </div>
 
-<Portal>
-  {#if isNowPlayingViewVisible}
-    <!-- Backdrop -->
-    <div transition:fade={{ duration: 300 }} class="z-199 fixed inset-0 bg-slate-950/50"></div>
-
-    <!-- Modal -->
-    <div
-      class="z-200 fixed inset-0 bg-slate-950 text-white"
-      transition:fly={{ duration: 300, y: '100%', opacity: 1 }}
-    >
-      <div class="mx-auto flex h-full w-full max-w-5xl flex-col px-4 py-3">
-        <!-- Navigation -->
-        <div class="flex items-center">
-          <button
-            class="cursor-pointer rounded-full p-4 transition-colors hover:bg-white/20 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
-            onclick={handleNowPlayingViewClose}
-          >
-            <ArrowLeft />
-          </button>
-        </div>
-
-        <div class="flex-1"></div>
-
-        <div class="flex flex-col gap-y-6">
-          <!-- Badge and Title -->
-          <div class="flex flex-col gap-y-3">
-            <Badge variant="purple">Special Educational Needs</Badge>
-            <a
-              href="/content/1"
-              class="w-fit text-xl focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
-            >
-              Navigating Special Educational Needs: A Path to Inclusion
-            </a>
-          </div>
-
-          <div class="flex flex-col gap-y-5">
-            <!-- Slider and Timestamp -->
-            <div class="flex flex-col gap-y-2">
-              <div class="group relative h-2 rounded-full bg-slate-700">
-                <div class="h-full w-3/4 rounded-full bg-white"></div>
-                <div
-                  class="absolute left-3/4 top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full bg-white opacity-0 transition-opacity group-hover:opacity-100"
-                ></div>
-              </div>
-
-              <div class="flex justify-between">
-                <span>14:32</span>
-                <span>-2.00</span>
-              </div>
-            </div>
-
-            <!-- Speed Control -->
-            <div class="flex justify-center">
-              <button
-                class="flex cursor-pointer items-center rounded-full bg-white/20 px-4 py-2 transition-colors hover:bg-white/30 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
-              >
-                <span class="text-sm font-medium">1.0x speed</span>
-              </button>
-            </div>
-
-            <!-- Playback Controls -->
-            <div class="flex justify-between py-4">
-              <!-- Backward Button -->
-              <button
-                class="cursor-pointer rounded-full p-4 transition-colors hover:bg-white/20 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
-              >
-                <SkipBack />
-              </button>
-
-              <!-- Replay Button -->
-              <button
-                class="cursor-pointer rounded-full p-4 transition-colors hover:bg-white/20 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
-              >
-                <RotateCcw />
-              </button>
-
-              <!-- Play/Pause Button -->
-              <button
-                class="cursor-pointer rounded-full bg-white p-4 text-black transition-colors hover:bg-white/75 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
-              >
-                <Pause />
-              </button>
-
-              <!-- Forward Button -->
-              <button
-                class="cursor-pointer rounded-full p-4 transition-colors hover:bg-white/20 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
-              >
-                <RotateCw />
-              </button>
-
-              <!-- Next Button -->
-              <button
-                class="cursor-pointer rounded-full p-4 transition-colors hover:bg-white/20 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
-              >
-                <SkipForward />
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  {/if}
-</Portal>
+<NowPlayingView isvisible={isNowPlayingViewVisible} onclose={handleNowPlayingViewClose} />


### PR DESCRIPTION
## 🚀 Summary

This PR introduces the `Modal` and `NowPlayingView` components. 

The `Modal` component includes a `variant` prop to control its background color and a `size` prop to determine whether it is displayed as a full-page or partial view. It automatically sets `overflow` on the document body when visible, and supports closing via the `Escape` key or by clicking the backdrop. 

> **Note:** The background color will be controlled via a prop rather than a class, as classes are typically reserved as an escape hatch for overriding defaults.  

The `NowPlayingView` component wraps the `Modal` and contains the now playing view elements that were previously inlined in the root layout.  

## ✏️ Changes

- Added `Modal` component with backdrop, `Escape` key handling, and body overflow locking when visible
- Added `NowPlayingView` component
- Adjusted padding in the playback controls within `NowPlayingView` to `p-3 sm:p-4`. The minimum supported width is 300 px, and the original `p-4` caused the layout to overshoot at that size.  