### PR TITLE
feat(learner): add handler when user takes a quiz

### DIFF
--- a/apps/learner/src/routes/content/[id]/+page.svelte
+++ b/apps/learner/src/routes/content/[id]/+page.svelte
@@ -6,6 +6,7 @@
   import { Badge } from '$lib/components/Badge/index.js';
   import { Button, LinkButton } from '$lib/components/Button/index.js';
   import { IsWithinViewport } from '$lib/helpers/index.js';
+  import { Player } from '$lib/states/player.svelte.js';
 
   const { data } = $props();
 
@@ -14,6 +15,7 @@
   let target = $state<HTMLElement | null>(null);
 
   const isWithinViewport = new IsWithinViewport(() => target);
+  const player = Player.get();
 
   afterNavigate(({ from, type }) => {
     if (type === 'enter' || !from) {
@@ -26,6 +28,10 @@
 
   const toggleIsExpanded = () => {
     isExpanded = !isExpanded;
+  };
+
+  const handleQuizClick = () => {
+    player.stop();
   };
 </script>
 
@@ -87,7 +93,12 @@
             <span class="font-medium">Play</span>
           </Button>
 
-          <LinkButton variant="secondary" width="full" href={`/content/${data.id}/quiz`}>
+          <LinkButton
+            variant="secondary"
+            width="full"
+            href={`/content/${data.id}/quiz`}
+            onclick={handleQuizClick}
+          >
             <Lightbulb class="h-4 w-4" />
             <span class="font-medium">Take the quiz</span>
           </LinkButton>


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->
This PR adds the `handleQuizClick` to stop a playing track when the user takes a quiz

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->
- Added `handleQuizClick` handler calling the `stop` method of the Player state