### PR TITLE
feat(learner): standarise page layout

### DIFF
--- a/apps/learner/src/app.html
+++ b/apps/learner/src/app.html
@@ -1,15 +1,12 @@
 <!doctype html>
-<html lang="en" class="h-full">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="%sveltekit.assets%/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     %sveltekit.head%
   </head>
-  <body
-    data-sveltekit-preload-data="hover"
-    class="font-geist flex min-h-full bg-slate-100 text-slate-950"
-  >
+  <body data-sveltekit-preload-data="hover" class="font-geist bg-slate-100 text-slate-950">
     <div class="contents">%sveltekit.body%</div>
   </body>
 </html>

--- a/apps/learner/src/lib/components/Starfield/Starfield.svelte
+++ b/apps/learner/src/lib/components/Starfield/Starfield.svelte
@@ -51,7 +51,7 @@
 
 <svg
   class={[
-    '-z-1 pointer-events-none absolute inset-0 mx-auto min-h-full w-full max-w-5xl px-4 py-3',
+    '-z-1 pointer-events-none absolute inset-0 mx-auto min-h-svh w-full max-w-5xl px-4 py-3',
     clazz,
   ]}
   {...otherProps}

--- a/apps/learner/src/routes/(protected)/(core)/+layout.svelte
+++ b/apps/learner/src/routes/(protected)/(core)/+layout.svelte
@@ -101,8 +101,6 @@
   </div>
 </header>
 
-<main class="pt-43 pb-25 relative mx-auto min-h-full w-full max-w-5xl px-4">
-  <div bind:this={target} class="absolute inset-x-0 top-0 h-px"></div>
+<div bind:this={target} class="absolute inset-x-0 top-0 h-px"></div>
 
-  {@render children()}
-</main>
+{@render children()}

--- a/apps/learner/src/routes/(protected)/(core)/+page.svelte
+++ b/apps/learner/src/routes/(protected)/(core)/+page.svelte
@@ -22,7 +22,7 @@
   };
 </script>
 
-<div class="flex flex-col gap-y-3">
+<main class="pt-43 relative mx-auto flex min-h-svh max-w-5xl flex-col gap-y-3 px-4 pb-28">
   <div class="px-2">
     <span class="text-xl font-semibold">Recently learned</span>
   </div>
@@ -43,4 +43,4 @@
       />
     {/each}
   </div>
-</div>
+</main>

--- a/apps/learner/src/routes/(protected)/(core)/explore/+page.svelte
+++ b/apps/learner/src/routes/(protected)/(core)/explore/+page.svelte
@@ -1,1 +1,3 @@
-<div class="px-2">Explore page!</div>
+<main class="pt-43 relative mx-auto flex min-h-svh max-w-5xl flex-col px-4 pb-28">
+  <div class="px-2">Explore page!</div>
+</main>

--- a/apps/learner/src/routes/(protected)/(core)/learning/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/(core)/learning/+page.server.ts
@@ -2,7 +2,7 @@ import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
   return {
-    learningJourneys: [
+    collections: [
       {
         id: 1,
         tag: 'Special Educational Needs',

--- a/apps/learner/src/routes/(protected)/(core)/learning/+page.svelte
+++ b/apps/learner/src/routes/(protected)/(core)/learning/+page.svelte
@@ -4,21 +4,21 @@
   const { data } = $props();
 </script>
 
-<div class="flex flex-col gap-y-3">
+<main class="pt-43 relative mx-auto flex min-h-svh max-w-5xl flex-col gap-y-3 px-4 pb-28">
   <div class="px-2">
     <span class="text-xl font-semibold">Your learnings</span>
   </div>
 
-  <div class="flex flex-col gap-y-3">
-    {#each data.learningJourneys as learning (learning.id)}
+  <div class="flex flex-col gap-y-4">
+    {#each data.collections as collection (collection.id)}
       <Collection
-        to={learning.to}
-        tag={learning.tag}
-        title={learning.title}
-        numberofpodcasts={learning.numberofpodcasts}
-        numberofnotes={learning.numberofnotes}
-        variant={learning.variant as CollectionProps['variant']}
+        to={collection.to}
+        tag={collection.tag}
+        title={collection.title}
+        numberofpodcasts={collection.numberofpodcasts}
+        numberofnotes={collection.numberofnotes}
+        variant={collection.variant as CollectionProps['variant']}
       />
     {/each}
   </div>
-</div>
+</main>

--- a/apps/learner/src/routes/(protected)/collection/[id]/+page.svelte
+++ b/apps/learner/src/routes/(protected)/collection/[id]/+page.svelte
@@ -33,53 +33,51 @@
   </div>
 </header>
 
-<main class="pt-23 relative mx-auto min-h-full w-full max-w-5xl px-4 pb-3">
-  <div bind:this={target} class="absolute inset-x-0 top-0 h-px"></div>
+<div bind:this={target} class="absolute inset-x-0 top-0 h-px"></div>
 
-  <div class="flex flex-col gap-y-6">
-    <div class="shadow-xs flex flex-col gap-y-2 rounded-3xl bg-slate-200 p-4">
-      <span class="text-lg font-medium">About this topic</span>
+<main class="pt-23 relative mx-auto flex min-h-svh max-w-5xl flex-col gap-y-6 px-4 pb-28">
+  <div class="shadow-xs flex flex-col gap-y-2 rounded-3xl bg-slate-200 p-4">
+    <span class="text-lg font-medium">About this topic</span>
 
-      <span>
-        Explore the world of Special Educational Needs (SEN) peer support that indicates Singapore
-        specific peer support knowledges, case studies and more to gain knowledge about SEN. This
-        topic encompasses a variety of bite-sized.
-      </span>
+    <span>
+      Explore the world of Special Educational Needs (SEN) peer support that indicates Singapore
+      specific peer support knowledges, case studies and more to gain knowledge about SEN. This
+      topic encompasses a variety of bite-sized.
+    </span>
+  </div>
+
+  <div class="flex flex-col gap-y-3">
+    <div class="px-2">
+      <span class="text-xl font-semibold">12 podcasts</span>
     </div>
 
-    <div class="flex flex-col gap-y-3">
-      <div class="px-2">
-        <span class="text-xl font-semibold">12 podcasts</span>
-      </div>
+    <div class="flex flex-col gap-y-4">
+      <LearningUnit
+        to="/content/1"
+        tags={[
+          { variant: 'purple', content: 'Special Educational Needs' },
+          { variant: 'slate', content: 'Podcast' },
+        ]}
+        title="Navigating Special Educational Needs in Singapore: A Path to Inclusion"
+      />
 
-      <div class="flex flex-col gap-y-4">
-        <LearningUnit
-          to="/content/1"
-          tags={[
-            { variant: 'purple', content: 'Special Educational Needs' },
-            { variant: 'slate', content: 'Podcast' },
-          ]}
-          title="Navigating Special Educational Needs in Singapore: A Path to Inclusion"
-        />
+      <LearningUnit
+        to="/content/1"
+        tags={[
+          { variant: 'purple', content: 'Special Educational Needs' },
+          { variant: 'slate', content: 'Podcast' },
+        ]}
+        title="Navigating Special Educational Needs in Singapore: A Path to Inclusion"
+      />
 
-        <LearningUnit
-          to="/content/1"
-          tags={[
-            { variant: 'purple', content: 'Special Educational Needs' },
-            { variant: 'slate', content: 'Podcast' },
-          ]}
-          title="Navigating Special Educational Needs in Singapore: A Path to Inclusion"
-        />
-
-        <LearningUnit
-          to="/content/1"
-          tags={[
-            { variant: 'purple', content: 'Special Educational Needs' },
-            { variant: 'slate', content: 'Podcast' },
-          ]}
-          title="Navigating Special Educational Needs in Singapore: A Path to Inclusion"
-        />
-      </div>
+      <LearningUnit
+        to="/content/1"
+        tags={[
+          { variant: 'purple', content: 'Special Educational Needs' },
+          { variant: 'slate', content: 'Podcast' },
+        ]}
+        title="Navigating Special Educational Needs in Singapore: A Path to Inclusion"
+      />
     </div>
   </div>
 </main>

--- a/apps/learner/src/routes/(protected)/content/[id]/+page.svelte
+++ b/apps/learner/src/routes/(protected)/content/[id]/+page.svelte
@@ -57,101 +57,97 @@
     ]}
   ></div>
 
-  <div class="mx-auto w-full max-w-5xl px-4 py-3">
-    <div class="flex items-center justify-between gap-x-8">
-      <a
-        href={returnTo}
-        class="rounded-full p-4 transition-colors hover:bg-slate-200 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
-      >
-        <ArrowLeft />
-      </a>
+  <div class="mx-auto flex w-full max-w-5xl items-center justify-between gap-x-8 px-4 py-3">
+    <a
+      href={returnTo}
+      class="rounded-full p-4 transition-colors hover:bg-slate-200 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+    >
+      <ArrowLeft />
+    </a>
 
-      <button
-        class="cursor-pointer rounded-full p-4 transition-colors hover:bg-slate-200 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
-      >
-        <Share />
-      </button>
-    </div>
+    <button
+      class="cursor-pointer rounded-full p-4 transition-colors hover:bg-slate-200 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+    >
+      <Share />
+    </button>
   </div>
 </header>
 
-<main class="pt-23 relative mx-auto min-h-full w-full max-w-5xl px-4 pb-3">
-  <div bind:this={target} class="absolute inset-x-0 top-0 h-px"></div>
+<div bind:this={target} class="absolute inset-x-0 top-0 h-px"></div>
 
-  <div class="flex flex-col gap-y-6">
-    <div class="shadow-xs flex flex-col gap-y-2 rounded-3xl bg-white p-4">
-      <div class="flex flex-wrap gap-1">
-        {#each data.tags as tag (tag)}
-          <Badge variant="purple">{tag}</Badge>
-        {/each}
-      </div>
+<main class="pt-23 relative mx-auto flex min-h-svh max-w-5xl flex-col gap-y-6 px-4 pb-28">
+  <div class="shadow-xs flex flex-col gap-y-2 rounded-3xl bg-white p-4">
+    <div class="flex flex-wrap gap-1">
+      {#each data.tags as tag (tag)}
+        <Badge variant="purple">{tag}</Badge>
+      {/each}
+    </div>
 
-      <div class="flex flex-col gap-y-6">
-        <div class="flex flex-col gap-y-3">
-          <span class="text-xl font-medium text-slate-950">
-            {data.title}
+    <div class="flex flex-col gap-y-6">
+      <div class="flex flex-col gap-y-3">
+        <span class="text-xl font-medium text-slate-950">
+          {data.title}
+        </span>
+
+        <div class="flex gap-x-1">
+          <span class="text-sm text-slate-600">By Guidance Branch</span>
+          <span class="text-sm text-slate-600">•</span>
+          <span class="text-sm text-slate-600">
+            {formatDistanceToNow(data.createdAt, { addSuffix: true })}
           </span>
-
-          <div class="flex gap-x-1">
-            <span class="text-sm text-slate-600">By Guidance Branch</span>
-            <span class="text-sm text-slate-600">•</span>
-            <span class="text-sm text-slate-600">
-              {formatDistanceToNow(data.createdAt, { addSuffix: true })}
-            </span>
-          </div>
-        </div>
-
-        <div class="flex flex-col gap-y-4">
-          {#if isActive && player.isPlaying}
-            <Button variant="primary" width="full" onclick={handlePause}>
-              <Pause class="h-4 w-4" />
-              <span class="font-medium">Pause</span>
-            </Button>
-          {:else if isActive && !player.isPlaying}
-            <Button variant="primary" width="full" onclick={handleResume}>
-              <Play class="h-4 w-4" />
-              <span class="font-medium">Resume</span>
-            </Button>
-          {:else}
-            <Button
-              variant="primary"
-              width="full"
-              onclick={() => handlePlay({ id: data.id, title: data.title })}
-            >
-              <Play class="h-4 w-4" />
-              <span class="font-medium">Play</span>
-            </Button>
-          {/if}
-
-          <LinkButton variant="secondary" width="full" href={`/content/${data.id}/quiz`}>
-            <Lightbulb class="h-4 w-4" />
-            <span class="font-medium">Take the quiz</span>
-          </LinkButton>
         </div>
       </div>
+
+      <div class="flex flex-col gap-y-4">
+        {#if isActive && player.isPlaying}
+          <Button variant="primary" width="full" onclick={handlePause}>
+            <Pause class="h-4 w-4" />
+            <span class="font-medium">Pause</span>
+          </Button>
+        {:else if isActive && !player.isPlaying}
+          <Button variant="primary" width="full" onclick={handleResume}>
+            <Play class="h-4 w-4" />
+            <span class="font-medium">Resume</span>
+          </Button>
+        {:else}
+          <Button
+            variant="primary"
+            width="full"
+            onclick={() => handlePlay({ id: data.id, title: data.title })}
+          >
+            <Play class="h-4 w-4" />
+            <span class="font-medium">Play</span>
+          </Button>
+        {/if}
+
+        <LinkButton variant="secondary" width="full" href={`/content/${data.id}/quiz`}>
+          <Lightbulb class="h-4 w-4" />
+          <span class="font-medium">Take the quiz</span>
+        </LinkButton>
+      </div>
+    </div>
+  </div>
+
+  <div class="flex flex-col items-center gap-y-4">
+    <div
+      class={[
+        'mask-b-from-10% max-h-28 overflow-hidden',
+        isExpanded && 'mask-b-from-100% max-h-full',
+      ]}
+    >
+      <p class={['line-clamp-4 text-lg', isExpanded && 'line-clamp-none']}>
+        {data.summary}
+      </p>
     </div>
 
-    <div class="flex flex-col items-center gap-y-4">
-      <div
-        class={[
-          'mask-b-from-10% max-h-28 overflow-hidden',
-          isExpanded && 'mask-b-from-100% max-h-full',
-        ]}
+    {#if !isExpanded}
+      <button
+        class="flex w-fit cursor-pointer items-center gap-x-1 px-4 py-2"
+        onclick={toggleIsExpanded}
       >
-        <p class={['line-clamp-4 text-lg', isExpanded && 'line-clamp-none']}>
-          {data.summary}
-        </p>
-      </div>
-
-      {#if !isExpanded}
-        <button
-          class="flex w-fit cursor-pointer items-center gap-x-1 px-4 py-2"
-          onclick={toggleIsExpanded}
-        >
-          <span class="text-sm font-medium">Read more</span>
-          <ChevronsDown class="h-4 w-4" />
-        </button>
-      {/if}
-    </div>
+        <span class="text-sm font-medium">Read more</span>
+        <ChevronsDown class="h-4 w-4" />
+      </button>
+    {/if}
   </div>
 </main>

--- a/apps/learner/src/routes/(protected)/content/[id]/+page.svelte
+++ b/apps/learner/src/routes/(protected)/content/[id]/+page.svelte
@@ -6,7 +6,7 @@
   import { Badge } from '$lib/components/Badge/index.js';
   import { Button, LinkButton } from '$lib/components/Button/index.js';
   import { IsWithinViewport } from '$lib/helpers/index.js';
-  import { Player, type Track } from '$lib/states/index.js';
+  import { Player } from '$lib/states/index.js';
 
   const { data } = $props();
 
@@ -32,11 +32,10 @@
     isExpanded = !isExpanded;
   };
 
-  // TODO: Change to LearningUnit type once it is added
-  const handlePlay = (learningUnit: Track) => {
+  const handlePlay = () => {
     player.play({
-      id: learningUnit.id,
-      title: learningUnit.title,
+      id: data.id,
+      title: data.title,
     });
   };
 
@@ -110,11 +109,7 @@
             <span class="font-medium">Resume</span>
           </Button>
         {:else}
-          <Button
-            variant="primary"
-            width="full"
-            onclick={() => handlePlay({ id: data.id, title: data.title })}
-          >
+          <Button variant="primary" width="full" onclick={handlePlay}>
             <Play class="h-4 w-4" />
             <span class="font-medium">Play</span>
           </Button>

--- a/apps/learner/src/routes/(protected)/profile/+page.svelte
+++ b/apps/learner/src/routes/(protected)/profile/+page.svelte
@@ -1,1 +1,3 @@
-<div class="px-2">Profile page!</div>
+<main class="pt-23 relative mx-auto flex min-h-svh max-w-5xl flex-col px-4 pb-28">
+  <div class="px-2">Profile page!</div>
+</main>

--- a/apps/learner/src/routes/+error.svelte
+++ b/apps/learner/src/routes/+error.svelte
@@ -4,20 +4,20 @@
   const is404 = page.status === 404;
 </script>
 
-<main class="relative mx-auto min-h-full w-full max-w-5xl px-4 py-3">
-  <div class="flex h-full flex-col items-center justify-center gap-y-4">
-    <div class="flex flex-col items-center gap-y-1">
-      <h1 class="text-center text-3xl font-bold">
-        {is404 ? 'Page not found' : 'Something went wrong'}
-      </h1>
+<main
+  class="relative mx-auto flex min-h-svh max-w-5xl flex-col items-center justify-center gap-y-4 px-4 py-3"
+>
+  <div class="flex flex-col items-center gap-y-1">
+    <h1 class="text-center text-3xl font-bold">
+      {is404 ? 'Page not found' : 'Something went wrong'}
+    </h1>
 
-      <p class="text-center text-sm text-slate-500">
-        {is404 ? 'The page you are looking for does not exist.' : 'Please try again later.'}
-      </p>
-    </div>
-
-    <a href="/" class="rounded-full bg-slate-950 px-4 py-3 text-center text-sm text-white">
-      Go to Home
-    </a>
+    <p class="text-center text-sm text-slate-500">
+      {is404 ? 'The page you are looking for does not exist.' : 'Please try again later.'}
+    </p>
   </div>
+
+  <a href="/" class="rounded-full bg-slate-950 px-4 py-3 text-center text-sm text-white">
+    Go to Home
+  </a>
 </main>

--- a/apps/learner/src/routes/login/+page.svelte
+++ b/apps/learner/src/routes/login/+page.svelte
@@ -6,101 +6,106 @@
 <main class="mx-auto flex min-h-svh w-full max-w-5xl flex-col px-4 py-3">
   <Starfield />
 
-  <div class="flex flex-col gap-y-3 p-5">
-    <div class="flex justify-center">
-      <svg width="48" height="48" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
-        <path
-          d="M16.0034 6.68726L17.7358 14.2625L25.3345 16.0007H25.3267L17.7358 17.7371L16.0034 25.3123V25.3337L16.0005 25.323L15.9985 25.3337V25.3123L14.2661 17.738L6.67236 16.0007H6.66846L14.2661 14.2625L15.9985 6.68726V6.66675L16.0005 6.67651L16.0034 6.66675V6.68726Z"
-          fill="currentColor"
-        />
-        <ellipse cx="15.9994" cy="2.8485" rx="0.848546" ry="0.848502" fill="currentColor" />
-        <ellipse cx="15.9994" cy="29.152" rx="0.848546" ry="0.848502" fill="currentColor" />
-        <ellipse
-          cx="29.1515"
-          cy="16.0001"
-          rx="0.848502"
-          ry="0.848546"
-          transform="rotate(90 29.1515 16.0001)"
-          fill="currentColor"
-        />
-        <ellipse
-          cx="2.84872"
-          cy="16.0001"
-          rx="0.848502"
-          ry="0.848546"
-          transform="rotate(90 2.84872 16.0001)"
-          fill="currentColor"
-        />
-        <circle
-          cx="0.848524"
-          cy="0.848524"
-          r="0.848524"
-          transform="matrix(-0.707112 0.707102 -0.707112 -0.707102 26.5024 25.2993)"
-          fill="currentColor"
-        />
-        <circle
-          cx="0.848524"
-          cy="0.848524"
-          r="0.848524"
-          transform="matrix(-0.707112 0.707102 -0.707112 -0.707102 7.90137 6.7002)"
-          fill="currentColor"
-        />
-        <circle
-          cx="0.848524"
-          cy="0.848524"
-          r="0.848524"
-          transform="matrix(-0.707112 -0.707102 0.707111 -0.707102 6.70068 26.5)"
-          fill="currentColor"
-        />
-        <circle
-          cx="0.848524"
-          cy="0.848524"
-          r="0.848524"
-          transform="matrix(-0.707112 -0.707102 0.707111 -0.707102 25.2988 7.90088)"
-          fill="currentColor"
-        />
-      </svg>
-    </div>
-
-    <span class="flex justify-center font-mono font-bold">Onward</span>
+  <div class="flex flex-col items-center justify-center gap-y-3 p-5">
+    {@render logo()}
+    <span class="font-mono font-bold">Onward</span>
   </div>
 
   <div class="flex flex-1 flex-col items-center justify-center">
     <span class="font-mono text-2xl font-bold">Get started.</span>
   </div>
 
-  <div class="flex flex-col gap-y-6 p-5">
-    <LinkButton href="/" variant="primary" width="full" class="gap-x-2">
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        preserveAspectRatio="xMidYMid"
-        viewBox="0 0 256 262"
-        width="16"
-        height="16"
-      >
-        <path
-          fill="#4285F4"
-          d="M255.878 133.451c0-10.734-.871-18.567-2.756-26.69H130.55v48.448h71.947c-1.45 12.04-9.283 30.172-26.69 42.356l-.244 1.622 38.755 30.023 2.685.268c24.659-22.774 38.875-56.282 38.875-96.027"
-        />
-        <path
-          fill="#34A853"
-          d="M130.55 261.1c35.248 0 64.839-11.605 86.453-31.622l-41.196-31.913c-11.024 7.688-25.82 13.055-45.257 13.055-34.523 0-63.824-22.773-74.269-54.25l-1.531.13-40.298 31.187-.527 1.465C35.393 231.798 79.49 261.1 130.55 261.1"
-        />
-        <path
-          fill="#FBBC05"
-          d="M56.281 156.37c-2.756-8.123-4.351-16.827-4.351-25.82 0-8.994 1.595-17.697 4.206-25.82l-.073-1.73L15.26 71.312l-1.335.635C5.077 89.644 0 109.517 0 130.55s5.077 40.905 13.925 58.602l42.356-32.782"
-        />
-        <path
-          fill="#EB4335"
-          d="M130.55 50.479c24.514 0 41.05 10.589 50.479 19.438l36.844-35.974C195.245 12.91 165.798 0 130.55 0 79.49 0 35.393 29.301 13.925 71.947l42.211 32.783c10.59-31.477 39.891-54.251 74.414-54.251"
-        />
-      </svg>
-
+  <div class="flex flex-col items-center justify-center gap-y-4 p-5">
+    <LinkButton href="/" variant="primary" width="full" class="max-w-sm gap-x-2">
+      {@render googleIcon()}
       <span class="font-medium">Continue with Google</span>
     </LinkButton>
 
-    <div class="text-center text-xs">
-      <span>By continuing, you agree to our <br />Terms and Privacy Policy.</span>
+    <div class="flex flex-col items-center justify-center text-xs">
+      <span>By continuing, you agree to our</span>
+      <span>Terms and Privacy Policy.</span>
     </div>
   </div>
 </main>
+
+{#snippet logo()}
+  <svg width="48" height="48" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M16.0034 6.68726L17.7358 14.2625L25.3345 16.0007H25.3267L17.7358 17.7371L16.0034 25.3123V25.3337L16.0005 25.323L15.9985 25.3337V25.3123L14.2661 17.738L6.67236 16.0007H6.66846L14.2661 14.2625L15.9985 6.68726V6.66675L16.0005 6.67651L16.0034 6.66675V6.68726Z"
+      fill="currentColor"
+    />
+    <ellipse cx="15.9994" cy="2.8485" rx="0.848546" ry="0.848502" fill="currentColor" />
+    <ellipse cx="15.9994" cy="29.152" rx="0.848546" ry="0.848502" fill="currentColor" />
+    <ellipse
+      cx="29.1515"
+      cy="16.0001"
+      rx="0.848502"
+      ry="0.848546"
+      transform="rotate(90 29.1515 16.0001)"
+      fill="currentColor"
+    />
+    <ellipse
+      cx="2.84872"
+      cy="16.0001"
+      rx="0.848502"
+      ry="0.848546"
+      transform="rotate(90 2.84872 16.0001)"
+      fill="currentColor"
+    />
+    <circle
+      cx="0.848524"
+      cy="0.848524"
+      r="0.848524"
+      transform="matrix(-0.707112 0.707102 -0.707112 -0.707102 26.5024 25.2993)"
+      fill="currentColor"
+    />
+    <circle
+      cx="0.848524"
+      cy="0.848524"
+      r="0.848524"
+      transform="matrix(-0.707112 0.707102 -0.707112 -0.707102 7.90137 6.7002)"
+      fill="currentColor"
+    />
+    <circle
+      cx="0.848524"
+      cy="0.848524"
+      r="0.848524"
+      transform="matrix(-0.707112 -0.707102 0.707111 -0.707102 6.70068 26.5)"
+      fill="currentColor"
+    />
+    <circle
+      cx="0.848524"
+      cy="0.848524"
+      r="0.848524"
+      transform="matrix(-0.707112 -0.707102 0.707111 -0.707102 25.2988 7.90088)"
+      fill="currentColor"
+    />
+  </svg>
+{/snippet}
+
+{#snippet googleIcon()}
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    preserveAspectRatio="xMidYMid"
+    viewBox="0 0 256 262"
+    width="16"
+    height="16"
+  >
+    <path
+      fill="#4285F4"
+      d="M255.878 133.451c0-10.734-.871-18.567-2.756-26.69H130.55v48.448h71.947c-1.45 12.04-9.283 30.172-26.69 42.356l-.244 1.622 38.755 30.023 2.685.268c24.659-22.774 38.875-56.282 38.875-96.027"
+    />
+    <path
+      fill="#34A853"
+      d="M130.55 261.1c35.248 0 64.839-11.605 86.453-31.622l-41.196-31.913c-11.024 7.688-25.82 13.055-45.257 13.055-34.523 0-63.824-22.773-74.269-54.25l-1.531.13-40.298 31.187-.527 1.465C35.393 231.798 79.49 261.1 130.55 261.1"
+    />
+    <path
+      fill="#FBBC05"
+      d="M56.281 156.37c-2.756-8.123-4.351-16.827-4.351-25.82 0-8.994 1.595-17.697 4.206-25.82l-.073-1.73L15.26 71.312l-1.335.635C5.077 89.644 0 109.517 0 130.55s5.077 40.905 13.925 58.602l42.356-32.782"
+    />
+    <path
+      fill="#EB4335"
+      d="M130.55 50.479c24.514 0 41.05 10.589 50.479 19.438l36.844-35.974C195.245 12.91 165.798 0 130.55 0 79.49 0 35.393 29.301 13.925 71.947l42.211 32.783c10.59-31.477 39.891-54.251 74.414-54.251"
+    />
+  </svg>
+{/snippet}


### PR DESCRIPTION
## 🚀 Summary

This PR replaces `min-h-full` with `min-h-svh` on all `main` containers to ensure the correct viewport height, rather than relying on parent elements to provide it. The quiz page and chat view modal will be updated in separate PRs.

## ✏️ Changes

- Applied `min-h-svh` to all `main` containers to set the correct viewport height
- Moved the `main` container from the core layout into individual pages for consistency
- Added bottom padding on certain pages to make space for the `NowPlayingBar` and `ChatWidget` components