### PR TITLE
fix(learner): use `sessionStorage` to store origin path when navigating to learning unit page

### DIFF
--- a/apps/learner/src/routes/(protected)/unit/[id]/+page.svelte
+++ b/apps/learner/src/routes/(protected)/unit/[id]/+page.svelte
@@ -3,6 +3,7 @@
   import { formatDistanceToNow } from 'date-fns';
 
   import { afterNavigate } from '$app/navigation';
+  import { page } from '$app/state';
   import { Badge } from '$lib/components/Badge/index.js';
   import { Button, LinkButton } from '$lib/components/Button/index.js';
   import { IsWithinViewport, tagCodeToBadgeVariant } from '$lib/helpers/index.js';
@@ -21,10 +22,15 @@
 
   afterNavigate(({ from, type }) => {
     if (type === 'enter' || !from) {
-      returnTo = '/';
       return;
     }
 
+    if (from.route.id && page.route.id && from.route.id.startsWith(page.route.id)) {
+      returnTo = sessionStorage.getItem('unit_origin') || '/';
+      return;
+    }
+
+    sessionStorage.setItem('unit_origin', from.url.pathname);
     returnTo = from.url.pathname;
   });
 
@@ -117,7 +123,7 @@
           </Button>
         {/if}
 
-        <LinkButton variant="secondary" width="full" href={`/content/${data.id}/quiz`}>
+        <LinkButton variant="secondary" width="full" href={`/unit/${data.id}/quiz`}>
           <Lightbulb class="h-4 w-4" />
           <span class="font-medium">Take the quiz</span>
         </LinkButton>

--- a/apps/learner/src/routes/(protected)/unit/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/(protected)/unit/[id]/quiz/+page.svelte
@@ -58,7 +58,7 @@
   <div class="mx-auto flex max-w-5xl items-center justify-between gap-x-3 px-4 py-3">
     <div class="flex items-center gap-x-3">
       <a
-        href="/content/{params.id}"
+        href="/unit/{params.id}"
         class="rounded-full p-4 transition-colors hover:bg-slate-200 focus-visible:outline-dashed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
       >
         <ArrowLeft />


### PR DESCRIPTION
Closes #102 

## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->
This PR aims to resolve an issue with content page `Back` button when navigating from quiz page. Currently clicking the `Back` arrow when directed back from quiz page will result in the page going back to the quiz page instead of the original page of origin. This fix will ensure that it will route back from where it came from (or Home page if user is redirected in externally)

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->
- Added `sessionStorage` to store the origin page so that when clicking `Back`, it will go to the correct route and not go back to quiz