### PR TITLE
feat(learner): add content page data

### DIFF
--- a/apps/learner/package.json
+++ b/apps/learner/package.json
@@ -25,6 +25,7 @@
     "@sveltejs/vite-plugin-svelte": "^6.1.0",
     "@tailwindcss/vite": "^4.1.11",
     "date-fns": "^4.1.0",
+    "prisma": "^6.8.2",
     "svelte": "^5.38.0",
     "svelte-check": "^4.3.0",
     "tailwindcss": "^4.1.11",

--- a/apps/learner/src/lib/states/player.svelte.ts
+++ b/apps/learner/src/lib/states/player.svelte.ts
@@ -7,7 +7,7 @@ const PLAYER_CONTEXT_KEY = Symbol('Player');
 const PLAYBACK_SPEED_OPTIONS = [0.5, 1.0, 1.5, 2.0];
 
 export interface Track {
-  id: number;
+  id: number | string | bigint;
   tags: string[];
   title: string;
   url: string;

--- a/apps/learner/src/routes/(protected)/content/[id]/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/content/[id]/+page.server.ts
@@ -23,12 +23,12 @@ export const load: PageServerLoad = async ({ params }) => {
     if (!learningUnit) throw error(404, 'Learning unit not found');
 
     return {
-      id: learningUnit.id.toString(),
+      id: learningUnit.id,
       tags: learningUnit.tags,
       title: learningUnit.title,
       summary: learningUnit.summary,
       url: learningUnit.contentURL,
-      createdAt: learningUnit.createdAt.toISOString(),
+      createdAt: learningUnit.createdAt,
     };
   } finally {
     await prisma.$disconnect();

--- a/apps/learner/src/routes/(protected)/content/[id]/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/content/[id]/+page.server.ts
@@ -1,13 +1,36 @@
+import { PrismaClient } from '@prisma/client';
+import { error } from '@sveltejs/kit';
+
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async () => {
-  return {
-    id: 1,
-    tags: ['Special Educational Needs'],
-    title: 'Navigating Special Educational Needs: A Path to Inclusion',
-    summary:
-      "This podcast explores how teachers in Singapore can effectively support students with Special Educational Needs (SEN) in mainstream classrooms, fostering inclusion through practical strategies and collaboration. Learn key approaches to address diverse learning needs, align with MOE's inclusive education goals, and create equitable learning environments.",
-    url: '/audio/ADHD in Classrooms_ Strategies That Work.wav',
-    createdAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
-  };
+export const load: PageServerLoad = async ({ params }) => {
+  const prisma = new PrismaClient();
+  try {
+    const id = BigInt(params.id);
+
+    const learningUnit = await prisma.learningUnit.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        tags: true,
+        title: true,
+        summary: true,
+        contentURL: true,
+        createdAt: true,
+      },
+    });
+
+    if (!learningUnit) throw error(404, 'Learning unit not found');
+
+    return {
+      id: learningUnit.id.toString(),
+      tags: learningUnit.tags,
+      title: learningUnit.title,
+      summary: learningUnit.summary,
+      url: learningUnit.contentURL,
+      createdAt: learningUnit.createdAt.toISOString(),
+    };
+  } finally {
+    await prisma.$disconnect();
+  }
 };

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "lint": "eslint \"**/*.{svelte,js,ts}\"",
     "prepare": "node \"./.husky/install.js\""
   },
+  "dependencies": {
+    "@prisma/client": "6.8.2"
+  },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
     "eslint": "^9.33.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@prisma/client':
+        specifier: 6.8.2
+        version: 6.8.2(prisma@6.8.2(typescript@5.9.2))(typescript@5.9.2)
     devDependencies:
       '@eslint/js':
         specifier: ^9.33.0
@@ -101,7 +105,7 @@ importers:
         version: 5.2.12(@sveltejs/kit@2.27.3(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.38.0)(vite@7.1.1(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)))(svelte@5.38.0)(vite@7.1.1(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)))
       '@sveltejs/enhanced-img':
         specifier: ^0.8.1
-        version: 0.8.1(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.38.0)(vite@7.1.1(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)))(rollup@4.41.1)(svelte@5.38.0)(vite@7.1.1(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
+        version: 0.8.1(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.38.0)(vite@7.1.1(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)))(rollup@4.46.2)(svelte@5.38.0)(vite@7.1.1(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
       '@sveltejs/kit':
         specifier: ^2.27.3
         version: 2.27.3(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.38.0)(vite@7.1.1(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)))(svelte@5.38.0)(vite@7.1.1(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
@@ -114,6 +118,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      prisma:
+        specifier: ^6.8.2
+        version: 6.8.2(typescript@5.9.2)
       svelte:
         specifier: ^5.38.0
         version: 5.38.0
@@ -3909,6 +3916,14 @@ snapshots:
     optionalDependencies:
       rollup: 4.41.1
 
+  '@rollup/pluginutils@5.1.4(rollup@4.46.2)':
+    dependencies:
+      '@types/estree': 1.0.7
+      estree-walker: 2.0.2
+      picomatch: 4.0.2
+    optionalDependencies:
+      rollup: 4.46.2
+
   '@rollup/rollup-android-arm-eabi@4.41.1':
     optional: true
 
@@ -4379,7 +4394,7 @@ snapshots:
       '@sveltejs/kit': 2.27.3(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.38.0)(vite@7.1.1(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)))(svelte@5.38.0)(vite@7.1.1(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
       rollup: 4.41.1
 
-  '@sveltejs/enhanced-img@0.8.1(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.38.0)(vite@7.1.1(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)))(rollup@4.41.1)(svelte@5.38.0)(vite@7.1.1(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))':
+  '@sveltejs/enhanced-img@0.8.1(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.38.0)(vite@7.1.1(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)))(rollup@4.46.2)(svelte@5.38.0)(vite@7.1.1(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 6.1.0(svelte@5.38.0)(vite@7.1.1(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
       magic-string: 0.30.17
@@ -4387,7 +4402,7 @@ snapshots:
       svelte: 5.38.0
       svelte-parse-markup: 0.1.5(svelte@5.38.0)
       vite: 7.1.1(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)
-      vite-imagetools: 8.0.0(rollup@4.41.1)
+      vite-imagetools: 8.0.0(rollup@4.46.2)
       zimmerframe: 1.1.2
     transitivePeerDependencies:
       - rollup
@@ -5791,9 +5806,9 @@ snapshots:
 
   uuid@9.0.1: {}
 
-  vite-imagetools@8.0.0(rollup@4.41.1):
+  vite-imagetools@8.0.0(rollup@4.46.2):
     dependencies:
-      '@rollup/pluginutils': 5.1.4(rollup@4.41.1)
+      '@rollup/pluginutils': 5.1.4(rollup@4.46.2)
       imagetools-core: 8.0.0
       sharp: 0.34.3
     transitivePeerDependencies:

--- a/prisma/migrations/20250905073854_add_summary_to_learning_unit_table/migration.sql
+++ b/prisma/migrations/20250905073854_add_summary_to_learning_unit_table/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `summary` to the `learning_units` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "learning_units" ADD COLUMN     "summary" TEXT NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,5 @@
-generator learner {
-  provider = "prisma-client"
-  output   = "../apps/learner/src/generated"
+generator client {
+  provider = "prisma-client-js"
 }
 
 datasource db {
@@ -55,6 +54,7 @@ model LearningUnit {
   tags        String[] @default([]) @map("tags") @db.VarChar(255)
   contentType String   @map("content_type") @db.VarChar(255)
   contentURL  String   @map("content_url")
+  summary     String   @map("summary")
 
   // Relations.
   collectionId BigInt @map("collection_id")


### PR DESCRIPTION
## 🚀 Summary

Implement server-side data fetching for the learner content page using Prisma, and extend the `LearningUnit` model with a `summary` field. This enables the page to load a learning unit by ID from PostgreSQL and display its metadata (`title`, `tags`, `summary`, `URL`, `timestamps`). 

## ✏️ Changes

* Added server-side load function (+page.server.ts) to fetch a LearningUnit by ID via Prisma
    * Parses params.id as BigInt
    * Selects id, tags, title, summary, contentURL, createdAt
    * Returns 404 when the learning unit is not found
    * Serializes BigInt and Date fields for the client
* Introduced summary field to the LearningUnit table/model
    * Updated Prisma schema
    * Ran migration to add summary column
* Ensured proper `Prisma` client lifecycle
    * Instantiated `PrismaClient` in the server load and `disconnected` in finally
