### PR TITLE
feat(learner): add content page data

### DIFF
--- a/apps/learner/src/lib/states/player.svelte.ts
+++ b/apps/learner/src/lib/states/player.svelte.ts
@@ -7,7 +7,7 @@ const PLAYER_CONTEXT_KEY = Symbol('Player');
 const PLAYBACK_SPEED_OPTIONS = [0.5, 1.0, 1.5, 2.0];
 
 export interface Track {
-  id: number;
+  id: number | string | bigint;
   tags: string[];
   title: string;
   url: string;

--- a/apps/learner/src/routes/(protected)/content/[id]/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/content/[id]/+page.server.ts
@@ -1,13 +1,36 @@
+import { PrismaClient } from '@prisma/client';
+import { error } from '@sveltejs/kit';
+
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async () => {
-  return {
-    id: 1,
-    tags: ['Special Educational Needs'],
-    title: 'Navigating Special Educational Needs: A Path to Inclusion',
-    summary:
-      "This podcast explores how teachers in Singapore can effectively support students with Special Educational Needs (SEN) in mainstream classrooms, fostering inclusion through practical strategies and collaboration. Learn key approaches to address diverse learning needs, align with MOE's inclusive education goals, and create equitable learning environments.",
-    url: '/audio/ADHD in Classrooms_ Strategies That Work.wav',
-    createdAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
-  };
+export const load: PageServerLoad = async ({ params }) => {
+  const prisma = new PrismaClient();
+  try {
+    const id = BigInt(params.id);
+
+    const learningUnit = await prisma.learningUnit.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        tags: true,
+        title: true,
+        summary: true,
+        contentURL: true,
+        createdAt: true,
+      },
+    });
+
+    if (!learningUnit) throw error(404, 'Learning unit not found');
+
+    return {
+      id: learningUnit.id,
+      tags: learningUnit.tags,
+      title: learningUnit.title,
+      summary: learningUnit.summary,
+      url: learningUnit.contentURL,
+      createdAt: learningUnit.createdAt,
+    };
+  } finally {
+    await prisma.$disconnect();
+  }
 };

--- a/apps/learner/src/routes/(protected)/content/[id]/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/content/[id]/+page.server.ts
@@ -1,36 +1,32 @@
-import { PrismaClient } from '@prisma/client';
 import { error } from '@sveltejs/kit';
+
+import { db } from '$lib/server/db';
 
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ params }) => {
-  const prisma = new PrismaClient();
-  try {
-    const id = BigInt(params.id);
+  const id = BigInt(params.id);
 
-    const learningUnit = await prisma.learningUnit.findUnique({
-      where: { id },
-      select: {
-        id: true,
-        tags: true,
-        title: true,
-        summary: true,
-        contentURL: true,
-        createdAt: true,
-      },
-    });
+  const learningUnit = await db.learningUnit.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      tags: true,
+      title: true,
+      summary: true,
+      contentURL: true,
+      createdAt: true,
+    },
+  });
 
-    if (!learningUnit) throw error(404, 'Learning unit not found');
+  if (!learningUnit) throw error(404, 'Learning unit not found');
 
-    return {
-      id: learningUnit.id,
-      tags: learningUnit.tags,
-      title: learningUnit.title,
-      summary: learningUnit.summary,
-      url: learningUnit.contentURL,
-      createdAt: learningUnit.createdAt,
-    };
-  } finally {
-    await prisma.$disconnect();
-  }
+  return {
+    id: learningUnit.id,
+    tags: learningUnit.tags,
+    title: learningUnit.title,
+    summary: learningUnit.summary,
+    url: learningUnit.contentURL,
+    createdAt: learningUnit.createdAt,
+  };
 };

--- a/apps/learner/src/routes/(protected)/content/[id]/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/content/[id]/+page.server.ts
@@ -5,10 +5,8 @@ import { db } from '$lib/server/db';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ params }) => {
-  const id = BigInt(params.id);
-
   const learningUnit = await db.learningUnit.findUnique({
-    where: { id },
+    where: { id: BigInt(params.id) },
     select: {
       id: true,
       tags: true,
@@ -19,7 +17,9 @@ export const load: PageServerLoad = async ({ params }) => {
     },
   });
 
-  if (!learningUnit) throw error(404, 'Learning unit not found');
+  if (!learningUnit) {
+    throw error(404);
+  }
 
   return {
     id: learningUnit.id,

--- a/prisma/migrations/20250908080148_add_summary_to_learning_unit_table/migration.sql
+++ b/prisma/migrations/20250908080148_add_summary_to_learning_unit_table/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `summary` to the `learning_units` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "learning_units" ADD COLUMN     "summary" TEXT NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,6 +55,7 @@ model LearningUnit {
   tags        String[] @default([]) @map("tags") @db.VarChar(255)
   contentType String   @map("content_type") @db.VarChar(255)
   contentURL  String   @map("content_url")
+  summary     String   @map("summary")
 
   // Relations.
   collectionId BigInt @map("collection_id")


### PR DESCRIPTION
## 🚀 Summary

Implement server-side data fetching for the learner content page using Prisma, and extend the `LearningUnit` model with a `summary` field. This enables the page to load a learning unit by ID from PostgreSQL and display its metadata (`title`, `tags`, `summary`, `URL`, `timestamps`). 

## ✏️ Changes

* Added server-side load function (+page.server.ts) to fetch a LearningUnit by ID via Prisma
    * Parses params.id as BigInt
    * Selects id, tags, title, summary, contentURL, createdAt
    * Returns 404 when the learning unit is not found
    * Serializes BigInt and Date fields for the client
* Introduced summary field to the LearningUnit table/model
    * Updated Prisma schema
    * Ran migration to add summary column
* Ensured proper `Prisma` client lifecycle
    * Instantiated `PrismaClient` in the server load and `disconnected` in finally
