### PR TITLE
feat(learner): enhance explore page to get data from database

### DIFF
--- a/apps/learner/prisma/migrations/20250918030826_add_created_by_to_learning_units_table/migration.sql
+++ b/apps/learner/prisma/migrations/20250918030826_add_created_by_to_learning_units_table/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `created_by` to the `learning_units` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."learning_units" ADD COLUMN     "created_by" TEXT NOT NULL;

--- a/apps/learner/prisma/migrations/20250918120241_add_type_to_collections_table/migration.sql
+++ b/apps/learner/prisma/migrations/20250918120241_add_type_to_collections_table/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `type` to the `collections` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "public"."CollectionType" AS ENUM ('SEN', 'AI');
+
+-- AlterTable
+ALTER TABLE "public"."collections" ADD COLUMN     "type" "public"."CollectionType" NOT NULL;

--- a/apps/learner/prisma/schema.prisma
+++ b/apps/learner/prisma/schema.prisma
@@ -52,6 +52,7 @@ model LearningUnit {
   contentType ContentType @map("content_type")
   contentURL  String      @map("content_url")
   summary     String      @map("summary")
+  createdBy   String      @map("created_by")
 
   // Relations.
   collectionId BigInt @map("collection_id")

--- a/apps/learner/prisma/schema.prisma
+++ b/apps/learner/prisma/schema.prisma
@@ -33,13 +33,19 @@ model Collection {
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
 
   // Domain-Specific Fields.
-  title String @map("title")
+  title String         @map("title")
+  type  CollectionType @map("type")
 
   // Relations.
   learningUnit LearningUnit[]
   tags         CollectionTag[]
 
   @@map("collections")
+}
+
+enum CollectionType {
+  SEN
+  AI
 }
 
 model LearningUnit {

--- a/apps/learner/prisma/seed.ts
+++ b/apps/learner/prisma/seed.ts
@@ -2,7 +2,12 @@ import 'dotenv/config';
 
 import { PrismaPg } from '@prisma/adapter-pg';
 
-import { ContentType, type Prisma, PrismaClient } from '../src/generated/prisma/client.js';
+import {
+  CollectionType,
+  ContentType,
+  type Prisma,
+  PrismaClient,
+} from '../src/generated/prisma/client.js';
 
 const db = new PrismaClient({
   adapter: new PrismaPg({
@@ -28,6 +33,7 @@ const collections: Prisma.CollectionCreateInput[] = [
   {
     id: 1,
     title: 'SEN Peer Support',
+    type: CollectionType.SEN,
     tags: {
       create: [
         {
@@ -43,6 +49,7 @@ const collections: Prisma.CollectionCreateInput[] = [
   {
     id: 2,
     title: 'Learn to use AI',
+    type: CollectionType.AI,
     tags: {
       create: [
         {

--- a/apps/learner/prisma/seed.ts
+++ b/apps/learner/prisma/seed.ts
@@ -65,6 +65,7 @@ const learningUnits: Prisma.LearningUnitCreateInput[] = [
     contentURL: 'http://localhost:5173',
     summary:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+    createdBy: 'DXD Product Team',
     collection: {
       connect: {
         id: collections[0].id,
@@ -89,6 +90,7 @@ const learningUnits: Prisma.LearningUnitCreateInput[] = [
     contentURL: 'http://localhost:5173',
     summary:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+    createdBy: 'DXD Product Team',
     collection: {
       connect: {
         id: collections[0].id,
@@ -113,6 +115,7 @@ const learningUnits: Prisma.LearningUnitCreateInput[] = [
     contentURL: 'http://localhost:5173',
     summary:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+    createdBy: 'DXD Product Team',
     collection: {
       connect: {
         id: collections[1].id,
@@ -137,6 +140,7 @@ const learningUnits: Prisma.LearningUnitCreateInput[] = [
     contentURL: 'http://localhost:5173',
     summary:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+    createdBy: 'DXD Product Team',
     collection: {
       connect: {
         id: collections[1].id,

--- a/apps/learner/src/lib/components/Collection/Collection.svelte
+++ b/apps/learner/src/lib/components/Collection/Collection.svelte
@@ -1,23 +1,15 @@
 <script lang="ts">
   import { Badge, type BadgeProps } from '$lib/components/Badge/index.js';
 
-  type Type = 'AI' | 'SEN' | 'MENTAL_HEALTH';
-
-  const colors: Record<Type, BadgeProps['variant']> = {
-    AI: 'amber',
-    SEN: 'purple',
-    MENTAL_HEALTH: 'teal',
-  };
-
   export interface Props {
     /**
      * The URL to navigate to when clicking the collection.
      */
     to: string;
     /**
-     * The tag to display on the collection.
+     * The tags to display on the collection.
      */
-    tag: string;
+    tags: { variant: BadgeProps['variant']; content: string }[];
     /**
      * The title of the collection.
      */
@@ -29,10 +21,10 @@
     /**
      * Defines the visual theme and icon for the collection.
      */
-    type: Type;
+    type: 'SEN' | 'AI';
   }
 
-  let { to, tag, title, numberofpodcasts, type }: Props = $props();
+  let { to, tags, title, numberofpodcasts, type }: Props = $props();
 </script>
 
 <a
@@ -45,14 +37,14 @@
         <enhanced:img src="$lib/assets/jupiter.png?w=200" alt={title} />
       {:else if type === 'AI'}
         <enhanced:img src="$lib/assets/stars.png?w=200" alt={title} />
-      {:else if type === 'MENTAL_HEALTH'}
-        <enhanced:img src="$lib/assets/saturn.png?w=200" alt={title} />
       {/if}
     </div>
 
     <div class="flex flex-col gap-y-2">
       <div class="flex flex-col gap-y-1">
-        <Badge variant={colors[type]}>{tag}</Badge>
+        {#each tags as tag (tag.content)}
+          <Badge variant={tag.variant}>{tag.content}</Badge>
+        {/each}
 
         <span class="text-xl font-semibold">
           {title}

--- a/apps/learner/src/lib/components/LearningUnit/LearningUnit.svelte
+++ b/apps/learner/src/lib/components/LearningUnit/LearningUnit.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Pause, Play } from '@lucide/svelte';
+  import { formatDistanceToNow } from 'date-fns';
   import type { MouseEventHandler } from 'svelte/elements';
 
   import { Badge, type BadgeProps } from '$lib/components/Badge/index.js';
@@ -18,6 +19,10 @@
      * The title of the card.
      */
     title: string;
+    /**
+     * Time at which the card is created.
+     */
+    createdAt: Date;
     /**
      * The creator of the card.
      */
@@ -50,7 +55,7 @@
     } | null;
   }
 
-  let { to, title, tags, createdBy, player = null }: Props = $props();
+  let { to, title, tags, createdAt, createdBy, player = null }: Props = $props();
 
   const handlePlay: MouseEventHandler<HTMLButtonElement> = (event) => {
     // Prevent default anchor navigation.
@@ -93,7 +98,9 @@
       <div class="flex gap-x-1">
         <span class="text-sm text-slate-600">{createdBy}</span>
         <span class="text-sm text-slate-600">•</span>
-        <span class="text-sm text-slate-600">2 days ago</span>
+        <span class="text-sm text-slate-600">
+          {formatDistanceToNow(createdAt, { addSuffix: true })}</span
+        >
       </div>
     </div>
   </div>

--- a/apps/learner/src/lib/components/LearningUnit/LearningUnit.svelte
+++ b/apps/learner/src/lib/components/LearningUnit/LearningUnit.svelte
@@ -20,13 +20,13 @@
      */
     title: string;
     /**
-     * Time at which the card is created.
+     * The time at which the card is created.
      */
-    createdAt: Date;
+    createdat: Date;
     /**
      * The creator of the card.
      */
-    createdBy: string;
+    createdby: string;
     /**
      * An optional player object for showing playback controls and progress.
      * If provided, displays the controls and progress.
@@ -55,7 +55,7 @@
     } | null;
   }
 
-  let { to, title, tags, createdAt, createdBy, player = null }: Props = $props();
+  let { to, title, tags, createdat, createdby, player = null }: Props = $props();
 
   const handlePlay: MouseEventHandler<HTMLButtonElement> = (event) => {
     // Prevent default anchor navigation.
@@ -96,10 +96,10 @@
       </span>
 
       <div class="flex gap-x-1">
-        <span class="text-sm text-slate-600">{createdBy}</span>
+        <span class="text-sm text-slate-600">{createdby}</span>
         <span class="text-sm text-slate-600">•</span>
         <span class="text-sm text-slate-600">
-          {formatDistanceToNow(createdAt, { addSuffix: true })}
+          {formatDistanceToNow(createdat, { addSuffix: true })}
         </span>
       </div>
     </div>

--- a/apps/learner/src/lib/components/LearningUnit/LearningUnit.svelte
+++ b/apps/learner/src/lib/components/LearningUnit/LearningUnit.svelte
@@ -19,6 +19,10 @@
      */
     title: string;
     /**
+     * The creator of the card.
+     */
+    createdBy: string;
+    /**
      * An optional player object for showing playback controls and progress.
      * If provided, displays the controls and progress.
      */
@@ -46,7 +50,7 @@
     } | null;
   }
 
-  let { to, title, tags, player = null }: Props = $props();
+  let { to, title, tags, createdBy, player = null }: Props = $props();
 
   const handlePlay: MouseEventHandler<HTMLButtonElement> = (event) => {
     // Prevent default anchor navigation.
@@ -87,7 +91,7 @@
       </span>
 
       <div class="flex gap-x-1">
-        <span class="text-sm text-slate-600">Guidance Branch</span>
+        <span class="text-sm text-slate-600">{createdBy}</span>
         <span class="text-sm text-slate-600">•</span>
         <span class="text-sm text-slate-600">2 days ago</span>
       </div>

--- a/apps/learner/src/lib/components/LearningUnit/LearningUnit.svelte
+++ b/apps/learner/src/lib/components/LearningUnit/LearningUnit.svelte
@@ -99,8 +99,8 @@
         <span class="text-sm text-slate-600">{createdBy}</span>
         <span class="text-sm text-slate-600">•</span>
         <span class="text-sm text-slate-600">
-          {formatDistanceToNow(createdAt, { addSuffix: true })}</span
-        >
+          {formatDistanceToNow(createdAt, { addSuffix: true })}
+        </span>
       </div>
     </div>
   </div>

--- a/apps/learner/src/routes/(protected)/(core)/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/(core)/+page.server.ts
@@ -8,6 +8,7 @@ export const load: PageServerLoad = async () => {
         tags: [{ code: 'SEN', label: 'Special Educational Needs' }],
         title: 'Navigating Special Education Needs in Singapore: A Path to Inclusion',
         url: 'ADHD in Classrooms_ Strategies That Work.wav',
+        createdAt: new Date(),
         createdBy: 'DXD Product Team',
       },
       {
@@ -15,6 +16,7 @@ export const load: PageServerLoad = async () => {
         tags: [{ code: 'SEN', label: 'Special Educational Needs' }],
         title: 'Testing the Waters: A Guide to Special Educational Needs in Singapore',
         url: 'ADHD in Classrooms_ Strategies That Work.wav',
+        createdAt: new Date(),
         createdBy: 'DXD Product Team',
       },
       {
@@ -22,6 +24,7 @@ export const load: PageServerLoad = async () => {
         tags: [{ code: 'SEN', label: 'Special Educational Needs' }],
         title: 'The quick brown fox jumps over the lazy dog',
         url: 'ADHD in Classrooms_ Strategies That Work.wav',
+        createdAt: new Date(),
         createdBy: 'DXD Product Team',
       },
     ],

--- a/apps/learner/src/routes/(protected)/(core)/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/(core)/+page.server.ts
@@ -8,18 +8,21 @@ export const load: PageServerLoad = async () => {
         tags: [{ code: 'SEN', label: 'Special Educational Needs' }],
         title: 'Navigating Special Education Needs in Singapore: A Path to Inclusion',
         url: 'ADHD in Classrooms_ Strategies That Work.wav',
+        createdBy: 'DXD Product Team',
       },
       {
         id: 2,
         tags: [{ code: 'SEN', label: 'Special Educational Needs' }],
         title: 'Testing the Waters: A Guide to Special Educational Needs in Singapore',
         url: 'ADHD in Classrooms_ Strategies That Work.wav',
+        createdBy: 'DXD Product Team',
       },
       {
         id: 3,
         tags: [{ code: 'SEN', label: 'Special Educational Needs' }],
         title: 'The quick brown fox jumps over the lazy dog',
         url: 'ADHD in Classrooms_ Strategies That Work.wav',
+        createdBy: 'DXD Product Team',
       },
     ],
   };

--- a/apps/learner/src/routes/(protected)/(core)/+page.svelte
+++ b/apps/learner/src/routes/(protected)/(core)/+page.svelte
@@ -39,6 +39,7 @@
           content: tag.label,
         }))}
         title={learningUnit.title}
+        createdAt={learningUnit.createdAt}
         createdBy={learningUnit.createdBy}
         player={{
           isactive: player.currentTrack?.id === learningUnit.id,

--- a/apps/learner/src/routes/(protected)/(core)/+page.svelte
+++ b/apps/learner/src/routes/(protected)/(core)/+page.svelte
@@ -39,8 +39,8 @@
           content: tag.label,
         }))}
         title={learningUnit.title}
-        createdAt={learningUnit.createdAt}
-        createdBy={learningUnit.createdBy}
+        createdat={learningUnit.createdAt}
+        createdby={learningUnit.createdBy}
         player={{
           isactive: player.currentTrack?.id === learningUnit.id,
           isplaying: player.isPlaying,

--- a/apps/learner/src/routes/(protected)/(core)/+page.svelte
+++ b/apps/learner/src/routes/(protected)/(core)/+page.svelte
@@ -39,6 +39,7 @@
           content: tag.label,
         }))}
         title={learningUnit.title}
+        createdBy={learningUnit.createdBy}
         player={{
           isactive: player.currentTrack?.id === learningUnit.id,
           isplaying: player.isPlaying,

--- a/apps/learner/src/routes/(protected)/(core)/explore/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/(core)/explore/+page.server.ts
@@ -6,10 +6,11 @@ export const load: PageServerLoad = async () => {
   const learningUnits = await db.learningUnit.findMany({
     select: {
       id: true,
+      createdAt: true,
       title: true,
       summary: true,
       contentURL: true,
-      createdAt: true,
+      createdBy: true,
       tags: {
         select: {
           tag: {

--- a/apps/learner/src/routes/(protected)/(core)/explore/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/(core)/explore/+page.server.ts
@@ -1,91 +1,61 @@
+import { db } from '$lib/server/db';
+
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
-  const learningUnits = [
-    {
-      id: 1,
-      to: '/content/1',
-      tags: [
-        { variant: 'purple', content: 'Special Educational Needs' },
-        { variant: 'slate', content: 'Podcast' },
-      ],
-      title: 'Navigating Special Educational Needs in Singapore: A Path to Inclusion',
+  const learningUnits = await db.learningUnit.findMany({
+    select: {
+      id: true,
+      title: true,
+      summary: true,
+      contentURL: true,
+      createdAt: true,
+      tags: {
+        select: {
+          tag: {
+            select: {
+              code: true,
+              label: true,
+            },
+          },
+        },
+      },
     },
-    {
-      id: 2,
-      to: '/content/1',
-      tags: [
-        { variant: 'purple', content: 'Special Educational Needs' },
-        { variant: 'slate', content: 'Podcast' },
-      ],
-      title: 'Navigating Special Educational Needs in Singapore: A Path to Inclusion',
-    },
-    {
-      id: 3,
-      to: '/content/1',
-      tags: [
-        { variant: 'purple', content: 'Special Educational Needs' },
-        { variant: 'slate', content: 'Podcast' },
-      ],
-      title: 'Navigating Special Educational Needs in Singapore: A Path to Inclusion',
-    },
-    {
-      id: 4,
-      to: '/content/1',
-      tags: [
-        { variant: 'purple', content: 'Special Educational Needs' },
-        { variant: 'slate', content: 'Podcast' },
-      ],
-      title: 'Navigating Special Educational Needs in Singapore: A Path to Inclusion',
-    },
-    {
-      id: 5,
-      to: '/content/1',
-      tags: [
-        { variant: 'purple', content: 'Special Educational Needs' },
-        { variant: 'slate', content: 'Podcast' },
-      ],
-      title: 'Navigating Special Educational Needs in Singapore: A Path to Inclusion',
-    },
-  ];
+    take: 4,
+  });
 
-  const collections = [
-    {
-      id: 1,
-      tag: 'Artificial Intelligence',
-      title: 'Learn to use AI',
-      numberofpodcasts: 8,
-      to: '/collection/1',
-      type: 'AI',
+  const collections = await db.collection.findMany({
+    select: {
+      id: true,
+      title: true,
+      type: true,
+      tags: {
+        select: {
+          tag: {
+            select: {
+              code: true,
+              label: true,
+            },
+          },
+        },
+      },
+      _count: {
+        select: {
+          learningUnit: true,
+        },
+      },
     },
-    {
-      id: 2,
-      tag: 'Special Educational Needs',
-      title: 'SEN peer support',
-      numberofpodcasts: 12,
-      to: '/collection/2',
-      type: 'SEN',
-    },
-    {
-      id: 3,
-      tag: 'Teacher mental health literacy',
-      title: 'Understanding Mental Health',
-      numberofpodcasts: 10,
-      to: '/collection/3',
-      type: 'MENTAL_HEALTH',
-    },
-    {
-      id: 4,
-      tag: 'Teacher mental health literacy',
-      title: 'Understanding Mental Health',
-      numberofpodcasts: 10,
-      to: '/collection/3',
-      type: 'MENTAL_HEALTH',
-    },
-  ];
+  });
 
   return {
-    learningUnits: learningUnits.slice(0, 3),
-    collections: collections.slice(0, 3),
+    learningUnits: learningUnits.map((unit) => ({
+      ...unit,
+      tags: unit.tags.map((t) => t.tag),
+    })),
+    collections: collections.map((collection) => ({
+      ...collection,
+      tags: collection.tags.map((t) => t.tag),
+      numberOfPodcasts: collection._count.learningUnit,
+    })),
   };
 };

--- a/apps/learner/src/routes/(protected)/(core)/explore/+page.svelte
+++ b/apps/learner/src/routes/(protected)/(core)/explore/+page.svelte
@@ -26,6 +26,7 @@
             content: t.label,
           }))}
           title={learningUnit.title}
+          createdBy={learningUnit.createdBy}
         />
       {/each}
     </div>

--- a/apps/learner/src/routes/(protected)/(core)/explore/+page.svelte
+++ b/apps/learner/src/routes/(protected)/(core)/explore/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-  import { Collection, type CollectionProps } from '$lib/components/Collection/index.js';
-  import { LearningUnit, type LearningUnitProps } from '$lib/components/LearningUnit/index.js';
+  import { Collection } from '$lib/components/Collection/index.js';
+  import { LearningUnit } from '$lib/components/LearningUnit/index.js';
+  import { tagCodeToBadgeVariant } from '$lib/helpers/index.js';
 
   const { data } = $props();
 </script>
@@ -19,8 +20,11 @@
     <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
       {#each data.learningUnits as learningUnit (learningUnit.id)}
         <LearningUnit
-          to={learningUnit.to}
-          tags={learningUnit.tags as LearningUnitProps['tags']}
+          to="/content/{learningUnit.id}"
+          tags={learningUnit.tags.map((t) => ({
+            variant: tagCodeToBadgeVariant(t.code),
+            content: t.label,
+          }))}
           title={learningUnit.title}
         />
       {/each}
@@ -40,11 +44,14 @@
     <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
       {#each data.collections as collection (collection.id)}
         <Collection
-          to={collection.to}
-          tag={collection.tag}
+          to="/collection/{collection.id}"
           title={collection.title}
-          numberofpodcasts={collection.numberofpodcasts}
-          type={collection.type as CollectionProps['type']}
+          type={collection.type}
+          tags={collection.tags.map((t) => ({
+            variant: tagCodeToBadgeVariant(t.code),
+            content: t.label,
+          }))}
+          numberofpodcasts={collection.numberOfPodcasts}
         />
       {/each}
     </div>

--- a/apps/learner/src/routes/(protected)/(core)/explore/+page.svelte
+++ b/apps/learner/src/routes/(protected)/(core)/explore/+page.svelte
@@ -26,8 +26,8 @@
             content: t.label,
           }))}
           title={learningUnit.title}
-          createdAt={learningUnit.createdAt}
-          createdBy={learningUnit.createdBy}
+          createdat={learningUnit.createdAt}
+          createdby={learningUnit.createdBy}
         />
       {/each}
     </div>

--- a/apps/learner/src/routes/(protected)/(core)/explore/+page.svelte
+++ b/apps/learner/src/routes/(protected)/(core)/explore/+page.svelte
@@ -45,16 +45,18 @@
     </div>
     <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
       {#each data.collections as collection (collection.id)}
-        <Collection
-          to="/collection/{collection.id}"
-          title={collection.title}
-          type={collection.type}
-          tags={collection.tags.map((t) => ({
-            variant: tagCodeToBadgeVariant(t.code),
-            content: t.label,
-          }))}
-          numberofpodcasts={collection.numberOfPodcasts}
-        />
+        {#if collection.numberOfPodcasts > 0}
+          <Collection
+            to="/collection/{collection.id}"
+            title={collection.title}
+            type={collection.type}
+            tags={collection.tags.map((t) => ({
+              variant: tagCodeToBadgeVariant(t.code),
+              content: t.label,
+            }))}
+            numberofpodcasts={collection.numberOfPodcasts}
+          />
+        {/if}
       {/each}
     </div>
   </div>

--- a/apps/learner/src/routes/(protected)/(core)/explore/+page.svelte
+++ b/apps/learner/src/routes/(protected)/(core)/explore/+page.svelte
@@ -26,6 +26,7 @@
             content: t.label,
           }))}
           title={learningUnit.title}
+          createdAt={learningUnit.createdAt}
           createdBy={learningUnit.createdBy}
         />
       {/each}

--- a/apps/learner/src/routes/(protected)/(core)/learning/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/(core)/learning/+page.server.ts
@@ -5,27 +5,17 @@ export const load: PageServerLoad = async () => {
     collections: [
       {
         id: 1,
-        tag: 'Artificial Intelligence',
         title: 'Learn to use AI',
-        numberofpodcasts: 8,
-        to: '/usercollection/1',
         type: 'AI',
+        tags: [{ code: 'AI', label: 'Artificial Intelligence' }],
+        numberofpodcasts: 8,
       },
       {
         id: 2,
-        tag: 'Special Educational Needs',
         title: 'SEN peer support',
-        numberofpodcasts: 12,
-        to: '/usercollection/2',
         type: 'SEN',
-      },
-      {
-        id: 3,
-        tag: 'Teacher mental health literacy',
-        title: 'Understanding Mental Health',
-        numberofpodcasts: 10,
-        to: '/usercollection/3',
-        type: 'MENTAL_HEALTH',
+        tags: [{ code: 'SEN', label: 'Special Educational Needs' }],
+        numberofpodcasts: 12,
       },
     ],
   };

--- a/apps/learner/src/routes/(protected)/(core)/learning/+page.svelte
+++ b/apps/learner/src/routes/(protected)/(core)/learning/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Collection, type CollectionProps } from '$lib/components/Collection/index.js';
+  import { tagCodeToBadgeVariant } from '$lib/helpers/index.js';
 
   const { data } = $props();
 </script>
@@ -12,11 +13,14 @@
   <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
     {#each data.collections as collection (collection.id)}
       <Collection
-        to={collection.to}
-        tag={collection.tag}
+        to={`/usercollection/${collection.id}`}
         title={collection.title}
-        numberofpodcasts={collection.numberofpodcasts}
         type={collection.type as CollectionProps['type']}
+        tags={collection.tags.map((t) => ({
+          variant: tagCodeToBadgeVariant(t.code),
+          content: t.label,
+        }))}
+        numberofpodcasts={collection.numberofpodcasts}
       />
     {/each}
   </div>

--- a/apps/learner/src/routes/(protected)/collection/[id]/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/collection/[id]/+page.server.ts
@@ -11,6 +11,8 @@ export const load: PageServerLoad = async () => {
           { variant: 'slate', content: 'Podcast' },
         ],
         title: 'Navigating Special Educational Needs in Singapore: A Path to Inclusion',
+        createdAt: new Date(),
+        createdBy: 'DXD Product Team',
       },
       {
         id: 2,
@@ -20,6 +22,8 @@ export const load: PageServerLoad = async () => {
           { variant: 'slate', content: 'Podcast' },
         ],
         title: 'Navigating Special Educational Needs in Singapore: A Path to Inclusion',
+        createdAt: new Date(),
+        createdBy: 'DXD Product Team',
       },
       {
         id: 3,
@@ -29,6 +33,8 @@ export const load: PageServerLoad = async () => {
           { variant: 'slate', content: 'Podcast' },
         ],
         title: 'Navigating Special Educational Needs in Singapore: A Path to Inclusion',
+        createdAt: new Date(),
+        createdBy: 'DXD Product Team',
       },
     ],
   };

--- a/apps/learner/src/routes/(protected)/collection/[id]/+page.svelte
+++ b/apps/learner/src/routes/(protected)/collection/[id]/+page.svelte
@@ -58,6 +58,8 @@
           to={learningUnit.to}
           tags={learningUnit.tags as LearningUnitProps['tags']}
           title={learningUnit.title}
+          createdAt={learningUnit.createdAt}
+          createdBy={learningUnit.createdBy}
         />
       {/each}
     </div>

--- a/apps/learner/src/routes/(protected)/collection/[id]/+page.svelte
+++ b/apps/learner/src/routes/(protected)/collection/[id]/+page.svelte
@@ -58,8 +58,8 @@
           to={learningUnit.to}
           tags={learningUnit.tags as LearningUnitProps['tags']}
           title={learningUnit.title}
-          createdAt={learningUnit.createdAt}
-          createdBy={learningUnit.createdBy}
+          createdat={learningUnit.createdAt}
+          createdby={learningUnit.createdBy}
         />
       {/each}
     </div>

--- a/apps/learner/src/routes/(protected)/content/[id]/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/content/[id]/+page.server.ts
@@ -23,6 +23,7 @@ export const load: PageServerLoad = async ({ params }) => {
       summary: true,
       contentURL: true,
       createdAt: true,
+      createdBy: true,
     },
   });
 
@@ -37,5 +38,6 @@ export const load: PageServerLoad = async ({ params }) => {
     summary: learningUnit.summary,
     url: learningUnit.contentURL,
     createdAt: learningUnit.createdAt,
+    createdBy: learningUnit.createdBy,
   };
 };

--- a/apps/learner/src/routes/(protected)/content/[id]/+page.svelte
+++ b/apps/learner/src/routes/(protected)/content/[id]/+page.svelte
@@ -91,7 +91,7 @@
         </span>
 
         <div class="flex gap-x-1">
-          <span class="text-sm text-slate-600">By Guidance Branch</span>
+          <span class="text-sm text-slate-600">By {data.createdBy}</span>
           <span class="text-sm text-slate-600">•</span>
           <span class="text-sm text-slate-600">
             {formatDistanceToNow(data.createdAt, { addSuffix: true })}

--- a/apps/learner/src/routes/(protected)/usercollection/[id]/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/usercollection/[id]/+page.server.ts
@@ -11,6 +11,7 @@ export const load: PageServerLoad = async () => {
           { variant: 'slate', content: 'Podcast' },
         ],
         title: 'Navigating Special Educational Needs in Singapore: A Path to Inclusion',
+        createdAt: new Date(),
         createdBy: 'DXD Product Team',
       },
       {
@@ -21,6 +22,7 @@ export const load: PageServerLoad = async () => {
           { variant: 'slate', content: 'Podcast' },
         ],
         title: 'Navigating Special Educational Needs in Singapore: A Path to Inclusion',
+        createdAt: new Date(),
         createdBy: 'DXD Product Team',
       },
       {
@@ -31,6 +33,7 @@ export const load: PageServerLoad = async () => {
           { variant: 'slate', content: 'Podcast' },
         ],
         title: 'Navigating Special Educational Needs in Singapore: A Path to Inclusion',
+        createdAt: new Date(),
         createdBy: 'DXD Product Team',
       },
     ],

--- a/apps/learner/src/routes/(protected)/usercollection/[id]/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/usercollection/[id]/+page.server.ts
@@ -11,6 +11,7 @@ export const load: PageServerLoad = async () => {
           { variant: 'slate', content: 'Podcast' },
         ],
         title: 'Navigating Special Educational Needs in Singapore: A Path to Inclusion',
+        createdBy: 'DXD Product Team',
       },
       {
         id: 2,
@@ -20,6 +21,7 @@ export const load: PageServerLoad = async () => {
           { variant: 'slate', content: 'Podcast' },
         ],
         title: 'Navigating Special Educational Needs in Singapore: A Path to Inclusion',
+        createdBy: 'DXD Product Team',
       },
       {
         id: 3,
@@ -29,6 +31,7 @@ export const load: PageServerLoad = async () => {
           { variant: 'slate', content: 'Podcast' },
         ],
         title: 'Navigating Special Educational Needs in Singapore: A Path to Inclusion',
+        createdBy: 'DXD Product Team',
       },
     ],
   };

--- a/apps/learner/src/routes/(protected)/usercollection/[id]/+page.svelte
+++ b/apps/learner/src/routes/(protected)/usercollection/[id]/+page.svelte
@@ -49,8 +49,8 @@
           to={learningUnit.to}
           tags={learningUnit.tags as LearningUnitProps['tags']}
           title={learningUnit.title}
-          createdAt={learningUnit.createdAt}
-          createdBy={learningUnit.createdBy}
+          createdat={learningUnit.createdAt}
+          createdby={learningUnit.createdBy}
         />
       {/each}
     </div>
@@ -67,8 +67,8 @@
           to={learningUnit.to}
           tags={learningUnit.tags as LearningUnitProps['tags']}
           title={learningUnit.title}
-          createdAt={learningUnit.createdAt}
-          createdBy={learningUnit.createdBy}
+          createdat={learningUnit.createdAt}
+          createdby={learningUnit.createdBy}
         />
       {/each}
     </div>

--- a/apps/learner/src/routes/(protected)/usercollection/[id]/+page.svelte
+++ b/apps/learner/src/routes/(protected)/usercollection/[id]/+page.svelte
@@ -49,6 +49,7 @@
           to={learningUnit.to}
           tags={learningUnit.tags as LearningUnitProps['tags']}
           title={learningUnit.title}
+          createdAt={learningUnit.createdAt}
           createdBy={learningUnit.createdBy}
         />
       {/each}
@@ -66,6 +67,7 @@
           to={learningUnit.to}
           tags={learningUnit.tags as LearningUnitProps['tags']}
           title={learningUnit.title}
+          createdAt={learningUnit.createdAt}
           createdBy={learningUnit.createdBy}
         />
       {/each}

--- a/apps/learner/src/routes/(protected)/usercollection/[id]/+page.svelte
+++ b/apps/learner/src/routes/(protected)/usercollection/[id]/+page.svelte
@@ -49,6 +49,7 @@
           to={learningUnit.to}
           tags={learningUnit.tags as LearningUnitProps['tags']}
           title={learningUnit.title}
+          createdBy={learningUnit.createdBy}
         />
       {/each}
     </div>
@@ -65,6 +66,7 @@
           to={learningUnit.to}
           tags={learningUnit.tags as LearningUnitProps['tags']}
           title={learningUnit.title}
+          createdBy={learningUnit.createdBy}
         />
       {/each}
     </div>


### PR DESCRIPTION
Closes #195

## 🚀 Summary

This PR aims to replace hardcoded data with actual data from database. This is done through implementing server-side data fetching for the learner explore page using Prisma, and extend the `LearningUnit` model with a `createdBy` field. This enables the page to load top 4 learning units and collections from the database.

## ✏️ Changes

- Added server-side load function (`+page.server.ts`) to fetch first 4 `LearningUnits` and `Collections`
- Added `created_by` to `LearningUnit` model
- Updated `LearningUnit` component with `createdAt` and `createdBy` props to get actual data instead of hardcoded data
- Updated all pages with latest props
