### PR TITLE
fix(learner): use `$effect.pre` when initialising audio player

### DIFF
--- a/apps/learner/src/lib/states/player.svelte.ts
+++ b/apps/learner/src/lib/states/player.svelte.ts
@@ -49,7 +49,7 @@ export class Player {
   #audio: HTMLAudioElement | null = null;
 
   constructor() {
-    $effect(() => {
+    $effect.pre(() => {
       this.#audio = new Audio();
 
       this.#audio.onloadedmetadata = () => {


### PR DESCRIPTION
## 🚀 Summary

This PR fixes a bug when using `$effect` to initialise the audio object. The effect in the pages will executes first before the effect in the layout which cause the audio being `null`.

## ✏️ Changes

- Used `$effect.pre` to initialise the audio object
