### PR TITLE
feat(learner): update profile content data with dynamic data

### DIFF
--- a/apps/learner/src/routes/(protected)/profile/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/profile/+page.server.ts
@@ -45,6 +45,7 @@ export const load: PageServerLoad = async (event) => {
       { err, userId },
       'Unknown error occurred while retrieving learning journey counts',
     );
+
     throw error(500);
   }
 };

--- a/apps/learner/src/routes/(protected)/profile/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/profile/+page.server.ts
@@ -51,9 +51,10 @@ export const load: PageServerLoad = async (event) => {
       learningUnitsCompletedByWeek: learningUnitsCompletedByWeek,
     };
   } catch (err) {
-    logger
-      .child({ userId })
-      .error(err, 'Unknown error occurred while retrieving learning journey counts');
+    logger.error(
+      { err, userId },
+      'Unknown error occurred while retrieving learning journey counts',
+    );
     throw error(500);
   }
 };

--- a/apps/learner/src/routes/(protected)/profile/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/profile/+page.server.ts
@@ -18,18 +18,16 @@ export const load: PageServerLoad = async (event) => {
   const firstOfMonth = startOfMonth(now);
   const startOfWeekMonday = startOfWeek(now, { weekStartsOn: 1 });
 
-  const userId = BigInt(user.id);
-
   try {
     const [byWeek, byMonth] = await Promise.all([
       db.learningJourney.groupBy({
         by: ['isCompleted'],
-        where: { userId, updatedAt: { gte: startOfWeekMonday } },
+        where: { userId: BigInt(user.id), updatedAt: { gte: startOfWeekMonday } },
         _count: { _all: true },
       }),
       db.learningJourney.groupBy({
         by: ['isCompleted'],
-        where: { userId, updatedAt: { gte: firstOfMonth } },
+        where: { userId: BigInt(user.id), updatedAt: { gte: firstOfMonth } },
         _count: { _all: true },
       }),
     ]);
@@ -44,7 +42,7 @@ export const load: PageServerLoad = async (event) => {
     };
   } catch (err) {
     logger.error(
-      { err, userId },
+      { err, userId: BigInt(user.id) },
       'Unknown error occurred while retrieving learning journey counts',
     );
 

--- a/apps/learner/src/routes/(protected)/profile/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/profile/+page.server.ts
@@ -37,8 +37,8 @@ export const load: PageServerLoad = async (event) => {
       email: user.email,
       learningUnitsConsumedByMonth: byMonth.reduce((total, group) => total + group._count._all, 0),
       learningUnitsConsumedByWeek: byWeek.reduce((total, group) => total + group._count._all, 0),
-      learningUnitsCompletedByMonth: byMonth.find((group) => group.isCompleted)?._count._all || 0,
-      learningUnitsCompletedByWeek: byWeek.find((group) => group.isCompleted)?._count._all || 0,
+      learningUnitsCompletedByMonth: byMonth.find((group) => group.isCompleted)?._count._all ?? 0,
+      learningUnitsCompletedByWeek: byWeek.find((group) => group.isCompleted)?._count._all ?? 0,
     };
   } catch (err) {
     logger.error(

--- a/apps/learner/src/routes/(protected)/profile/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/profile/+page.server.ts
@@ -1,12 +1,76 @@
+import { error } from '@sveltejs/kit';
+import { startOfMonth, startOfWeek } from 'date-fns';
+
+import { db } from '$lib/server/db';
+
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async () => {
+const validateSession = (event: Parameters<PageServerLoad>[0]): bigint => {
+  const userIdRaw = event.locals.session?.user?.id;
+  if (!userIdRaw) {
+    throw error(401, 'User is not authenticated');
+  }
+
+  try {
+    return BigInt(userIdRaw);
+  } catch {
+    throw error(400, 'Invalid user ID format');
+  }
+};
+
+export const load: PageServerLoad = async (event) => {
+  const userId = validateSession(event);
+
+  const user = await db.user.findUnique({
+    where: { id: userId },
+    select: { name: true, email: true },
+  });
+
+  if (!user) {
+    throw error(404, 'User not found');
+  }
+
+  const now = new Date();
+
+  const firstOfMonth = startOfMonth(now);
+  const startOfWeekMonday = startOfWeek(now, { weekStartsOn: 1 });
+
+  const learningUnitsConsumedByWeek = await db.learningJourney.count({
+    where: {
+      userId: userId,
+      updatedAt: { gte: startOfWeekMonday },
+    },
+  });
+
+  const learningUnitsCompletedByWeek = await db.learningJourney.count({
+    where: {
+      userId: userId,
+      isCompleted: true,
+      updatedAt: { gte: startOfWeekMonday },
+    },
+  });
+
+  const learningUnitsConsumedByMonth = await db.learningJourney.count({
+    where: {
+      userId: userId,
+      updatedAt: { gte: firstOfMonth },
+    },
+  });
+
+  const learningUnitsCompletedByMonth = await db.learningJourney.count({
+    where: {
+      userId: userId,
+      isCompleted: true,
+      updatedAt: { gte: firstOfMonth },
+    },
+  });
+
   return {
-    name: 'John Doe',
-    email: 'john.doe@example.com',
-    learningUnitsConsumedByMonth: '8',
-    learningUnitsConsumedByWeek: '6',
-    learningUnitsCompletedByMonth: '4',
-    learningUnitsCompletedByWeek: '2',
+    name: user.name,
+    email: user.email,
+    learningUnitsConsumedByMonth: learningUnitsConsumedByMonth.toString(),
+    learningUnitsConsumedByWeek: learningUnitsConsumedByWeek.toString(),
+    learningUnitsCompletedByMonth: learningUnitsCompletedByMonth.toString(),
+    learningUnitsCompletedByWeek: learningUnitsCompletedByWeek.toString(),
   };
 };

--- a/apps/learner/src/routes/(protected)/profile/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/profile/+page.server.ts
@@ -42,7 +42,7 @@ export const load: PageServerLoad = async (event) => {
     };
   } catch (err) {
     logger.error(
-      { err, userId: BigInt(user.id) },
+      { err, userId: user.id },
       'Unknown error occurred while retrieving learning journey counts',
     );
 

--- a/apps/learner/src/routes/(protected)/profile/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/profile/+page.server.ts
@@ -10,7 +10,7 @@ export const load: PageServerLoad = async (event) => {
 
   const { user } = event.locals.session;
   if (!user) {
-    logger.warn('User is not authenticated. Redirecting to /login.');
+    logger.warn('User is not authenticated.');
     return redirect(303, '/login');
   }
 

--- a/apps/learner/src/routes/(protected)/profile/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/profile/+page.server.ts
@@ -10,7 +10,7 @@ export const load: PageServerLoad = async (event) => {
 
   const { user } = event.locals.session;
   if (!user) {
-    logger.warn('User is not authenticated.');
+    logger.warn('User is not authenticated');
     return redirect(303, '/login');
   }
 

--- a/apps/learner/src/routes/(protected)/profile/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/profile/+page.server.ts
@@ -6,12 +6,13 @@ import { db } from '$lib/server/db';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async (event) => {
+  const logger = event.locals.logger.child({ handler: 'user_profile' });
+
   const { user } = event.locals.session;
   if (!user) {
+    logger.warn('User is not authenticated. Redirecting to /login.');
     return redirect(303, '/login');
   }
-
-  const logger = event.locals.logger.child({ handler: 'user_profile', user_id: user.id });
 
   const now = new Date();
   const firstOfMonth = startOfMonth(now);
@@ -50,7 +51,9 @@ export const load: PageServerLoad = async (event) => {
       learningUnitsCompletedByWeek: learningUnitsCompletedByWeek,
     };
   } catch (err) {
-    logger.error(err, 'Unknown error occurred while retrieving learning journey counts');
+    logger
+      .child({ userId })
+      .error(err, 'Unknown error occurred while retrieving learning journey counts');
     throw error(500);
   }
 };

--- a/apps/learner/src/routes/(protected)/profile/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/profile/+page.server.ts
@@ -32,23 +32,13 @@ export const load: PageServerLoad = async (event) => {
       }),
     ]);
 
-    const [learningUnitsConsumedByWeek, learningUnitsCompletedByWeek] = [
-      learningUnitsByWeek.length,
-      learningUnitsByWeek.filter((unit) => unit.isCompleted).length,
-    ];
-
-    const [learningUnitsConsumedByMonth, learningUnitsCompletedByMonth] = [
-      learningUnitsByMonth.length,
-      learningUnitsByMonth.filter((unit) => unit.isCompleted).length,
-    ];
-
     return {
       name: user.name,
       email: user.email,
-      learningUnitsConsumedByMonth: learningUnitsConsumedByMonth,
-      learningUnitsConsumedByWeek: learningUnitsConsumedByWeek,
-      learningUnitsCompletedByMonth: learningUnitsCompletedByMonth,
-      learningUnitsCompletedByWeek: learningUnitsCompletedByWeek,
+      learningUnitsConsumedByMonth: learningUnitsByMonth.length,
+      learningUnitsConsumedByWeek: learningUnitsByWeek.length,
+      learningUnitsCompletedByMonth: learningUnitsByMonth.filter((unit) => unit.isCompleted).length,
+      learningUnitsCompletedByWeek: learningUnitsByWeek.filter((unit) => unit.isCompleted).length,
     };
   } catch (err) {
     logger.error(


### PR DESCRIPTION
## 🚀 Summary

Added functionality to track learning unit activity and completion based on dynamic date ranges. This includes calculating the start of the current month and week (with Monday as the start of the week) and querying data accordingly.

## ✏️ Changes

- Integrated `date-fns` for date calculations:
  - Used `startOfMonth` to calculate the first day of the current month.
  - Used `startOfWeek` with `{ weekStartsOn: 1 }` to ensure Monday is treated as the start of the week.
- Updated learning unit queries:
  - Used `updatedAt` to track recent activity.
  - Added filtering logic for weekly and monthly activity based on calculated date ranges.
- Improved session validation:
  - Added `validateSession` function to ensure user authentication and handle invalid user IDs gracefully.
- Enhanced the `load` function:
  - Fetched user details (`name` and `email`) securely.
  - Calculated learning units consumed and completed for both the current week and month.
  - Returned all data as strings to ensure compatibility with JSON serialization.