### PR TITLE
fix(learner): use correct relative path for `prisma/seed.ts` in generated `tsconfig.json`

### DIFF
--- a/apps/learner/svelte.config.js
+++ b/apps/learner/svelte.config.js
@@ -8,7 +8,7 @@ export default {
     adapter: adapter(),
     typescript: {
       config: (cfg) => {
-        cfg.include.push('prisma/seed.ts');
+        cfg.include.push('../prisma/seed.ts');
       },
     },
   },


### PR DESCRIPTION
## 🚀 Summary

This PR fixes a misconfiguration that prevented `apps/learner/prisma/seed.ts` from being recognised by the Typescript language server. It is caused by using the wrong relative path in the generated `tsconfig.json`.

## ✏️ Changes

- Corrected the relative path for `prisma/seed.ts` from `prisma/seed.ts` → `../prisma/seed.ts` in the generated `tsconfig.json`