### PR TITLE
feat(learner): replace `name` column with `code` and `label` columns in tags table

### DIFF
--- a/apps/learner/prisma/migrations/20250918035634_replace_name_with_code_and_label_in_tags_table/migration.sql
+++ b/apps/learner/prisma/migrations/20250918035634_replace_name_with_code_and_label_in_tags_table/migration.sql
@@ -1,0 +1,19 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `name` on the `tags` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[code]` on the table `tags` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `code` to the `tags` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `label` to the `tags` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropIndex
+DROP INDEX "public"."tags_name_key";
+
+-- AlterTable
+ALTER TABLE "public"."tags" DROP COLUMN "name",
+ADD COLUMN     "code" VARCHAR(32) NOT NULL,
+ADD COLUMN     "label" VARCHAR(100) NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "tags_code_key" ON "public"."tags"("code");

--- a/apps/learner/prisma/migrations/20250918182401_update_code_length_in_tag_table/migration.sql
+++ b/apps/learner/prisma/migrations/20250918182401_update_code_length_in_tag_table/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to alter the column `code` on the `tags` table. The data in that column could be lost. The data in that column will be cast from `VarChar(32)` to `VarChar(8)`.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."tags" ALTER COLUMN "code" SET DATA TYPE VARCHAR(8);

--- a/apps/learner/prisma/schema.prisma
+++ b/apps/learner/prisma/schema.prisma
@@ -93,7 +93,8 @@ model Tag {
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
 
   // Domain-Specific Fields.
-  name String @unique @map("name") @db.VarChar(100)
+  code  String @unique @map("code") @db.VarChar(32) // e.g. "SEN"
+  label String @map("label") @db.VarChar(100) // e.g. "Special Educational Needs"
 
   // Relations.
   collections   CollectionTag[]

--- a/apps/learner/prisma/schema.prisma
+++ b/apps/learner/prisma/schema.prisma
@@ -93,7 +93,7 @@ model Tag {
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
 
   // Domain-Specific Fields.
-  code  String @unique @map("code") @db.VarChar(32) // e.g. "SEN"
+  code  String @unique @map("code") @db.VarChar(8) // e.g. "SEN"
   label String @map("label") @db.VarChar(100) // e.g. "Special Educational Needs"
 
   // Relations.

--- a/apps/learner/prisma/seed.ts
+++ b/apps/learner/prisma/seed.ts
@@ -14,11 +14,13 @@ const db = new PrismaClient({
 const tags: Prisma.TagCreateInput[] = [
   {
     id: 1,
-    name: 'Special Educational Needs',
+    code: 'SEN',
+    label: 'Special Educational Needs',
   },
   {
     id: 2,
-    name: 'Artificial Intelligence',
+    code: 'AI',
+    label: 'Artificial Intelligence',
   },
 ];
 

--- a/apps/learner/src/lib/helpers/index.ts
+++ b/apps/learner/src/lib/helpers/index.ts
@@ -1,4 +1,5 @@
 export * from './format.js';
 export * from './is-within-viewport.svelte.js';
+export * from './mapping.js';
 export * from './nanoid.js';
 export * from './noop.js';

--- a/apps/learner/src/lib/helpers/mapping.ts
+++ b/apps/learner/src/lib/helpers/mapping.ts
@@ -1,0 +1,23 @@
+import type { BadgeProps } from '$lib/components/Badge/index.js';
+
+/**
+ * Get the variant of the badge based on the given tag code.
+ *
+ * @param code - The code of the tag.
+ * @returns The variant of the badge.
+ *
+ * @example
+ * ```typescript
+ * const variant = tagCodeToBadgeVariant('SEN');
+ * ```
+ */
+export function tagCodeToBadgeVariant(code: string): BadgeProps['variant'] {
+  switch (code) {
+    case 'SEN':
+      return 'purple';
+    case 'AI':
+      return 'amber';
+    default:
+      return 'slate';
+  }
+}

--- a/apps/learner/src/lib/states/player.svelte.ts
+++ b/apps/learner/src/lib/states/player.svelte.ts
@@ -8,7 +8,7 @@ const PLAYBACK_SPEED_OPTIONS = [0.5, 1.0, 1.5, 2.0];
 
 export interface Track {
   id: number | string | bigint;
-  tags: string[];
+  tags: { code: string; label: string }[];
   title: string;
   url: string;
 }

--- a/apps/learner/src/routes/(protected)/(core)/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/(core)/+page.server.ts
@@ -5,19 +5,19 @@ export const load: PageServerLoad = async () => {
     learningUnits: [
       {
         id: 1,
-        tags: ['Special Educational Needs'],
+        tags: [{ code: 'SEN', label: 'Special Educational Needs' }],
         title: 'Navigating Special Education Needs in Singapore: A Path to Inclusion',
         url: 'ADHD in Classrooms_ Strategies That Work.wav',
       },
       {
         id: 2,
-        tags: ['Special Educational Needs'],
+        tags: [{ code: 'SEN', label: 'Special Educational Needs' }],
         title: 'Testing the Waters: A Guide to Special Educational Needs in Singapore',
         url: 'ADHD in Classrooms_ Strategies That Work.wav',
       },
       {
         id: 3,
-        tags: ['Special Educational Needs'],
+        tags: [{ code: 'SEN', label: 'Special Educational Needs' }],
         title: 'The quick brown fox jumps over the lazy dog',
         url: 'ADHD in Classrooms_ Strategies That Work.wav',
       },

--- a/apps/learner/src/routes/(protected)/(core)/+page.svelte
+++ b/apps/learner/src/routes/(protected)/(core)/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { LearningUnit } from '$lib/components/LearningUnit/index.js';
+  import { tagCodeToBadgeVariant } from '$lib/helpers/index.js';
   import { Player } from '$lib/states/index.js';
 
   const { data } = $props();
@@ -33,7 +34,10 @@
     {#each data.learningUnits as learningUnit (learningUnit.id)}
       <LearningUnit
         to={`/content/${learningUnit.id}`}
-        tags={learningUnit.tags.map((tag) => ({ variant: 'purple', content: tag }))}
+        tags={learningUnit.tags.map((tag) => ({
+          variant: tagCodeToBadgeVariant(tag.code),
+          content: tag.label,
+        }))}
         title={learningUnit.title}
         player={{
           isactive: player.currentTrack?.id === learningUnit.id,

--- a/apps/learner/src/routes/(protected)/content/[id]/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/content/[id]/+page.server.ts
@@ -13,7 +13,8 @@ export const load: PageServerLoad = async ({ params }) => {
         select: {
           tag: {
             select: {
-              name: true,
+              code: true,
+              label: true,
             },
           },
         },
@@ -31,7 +32,7 @@ export const load: PageServerLoad = async ({ params }) => {
 
   return {
     id: learningUnit.id,
-    tags: learningUnit.tags.map((t) => t.tag.name),
+    tags: learningUnit.tags.map((t) => t.tag),
     title: learningUnit.title,
     summary: learningUnit.summary,
     url: learningUnit.contentURL,

--- a/apps/learner/src/routes/(protected)/content/[id]/+page.svelte
+++ b/apps/learner/src/routes/(protected)/content/[id]/+page.svelte
@@ -5,7 +5,7 @@
   import { afterNavigate } from '$app/navigation';
   import { Badge } from '$lib/components/Badge/index.js';
   import { Button, LinkButton } from '$lib/components/Button/index.js';
-  import { IsWithinViewport } from '$lib/helpers/index.js';
+  import { IsWithinViewport, tagCodeToBadgeVariant } from '$lib/helpers/index.js';
   import { Player } from '$lib/states/index.js';
 
   const { data } = $props();
@@ -80,7 +80,7 @@
   <div class="shadow-xs flex flex-col gap-y-2 rounded-3xl bg-white p-4">
     <div class="flex flex-wrap gap-1">
       {#each data.tags as tag (tag)}
-        <Badge variant="purple">{tag}</Badge>
+        <Badge variant={tagCodeToBadgeVariant(tag.code)}>{tag.label}</Badge>
       {/each}
     </div>
 


### PR DESCRIPTION
## 🚀 Summary

This PR replaces `name` column with `code` and `label` in tags table. This is to guard against possible frequent name changes which will affect mapping to a color in the frontend which would lead to data migration and code changes.

## ✏️ Changes

- Replaced `name` column with `code` and `label` columns in tags table
- Added a mapping helper `tagCodeToBadgeVariant` for badge variants
