### PR TITLE
feat(learner): add learning journey data to seed.ts

### DIFF
--- a/apps/learner/prisma/seed.ts
+++ b/apps/learner/prisma/seed.ts
@@ -178,6 +178,46 @@ async function main() {
       create: learningUnit,
     });
   }
+
+  const firstUser = await db.user.findFirst();
+
+  if (!firstUser) {
+    console.error('No users found in the database. Please ensure at least one user exists.');
+    return;
+  }
+
+  const learningJourneys: Prisma.LearningJourneyCreateInput[] = [
+    {
+      id: 1,
+      isCompleted: false,
+      lastCheckpoint: 0,
+      user: {
+        connect: { id: firstUser.id },
+      },
+      learningUnit: {
+        connect: { id: 1 },
+      },
+    },
+    {
+      id: 2,
+      isCompleted: true,
+      lastCheckpoint: 100,
+      user: {
+        connect: { id: firstUser.id },
+      },
+      learningUnit: {
+        connect: { id: 2 },
+      },
+    },
+  ];
+
+  for (const learningJourney of learningJourneys) {
+    await db.learningJourney.upsert({
+      where: { id: learningJourney.id },
+      update: {},
+      create: learningJourney,
+    });
+  }
 }
 
 main()


### PR DESCRIPTION
## 🚀 Summary

This update enhances the database seeding script to include `LearningJourney` data seeding alongside the existing logic for `tags`, `collections`, and `learningUnits`. The `LearningJourney` data connects `users` to specific learning units, ensuring relationships between these entities are properly established. The script now dynamically fetches the first user from the database, validating the presence of at least one user before proceeding with LearningJourney seeding.


## ✏️ Changes

- Added a check to retrieve the first user (findFirst) from the database and validate its existence before proceeding with LearningJourney seeding.
  - If no users exist, a clear error message is logged, and the seeding process for LearningJourney is skipped.
- Added logic to associate LearningJourney data with the id of the fetched user using connect.