### PR TITLE
feat(learner): add dynamic `learning collection page` with content data

### DIFF
--- a/apps/learner/src/routes/(protected)/(core)/learning/+page.svelte
+++ b/apps/learner/src/routes/(protected)/(core)/learning/+page.svelte
@@ -13,7 +13,7 @@
   <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
     {#each data.collections as collection (collection.id)}
       <Collection
-        to="/learning/collection/{collection.id}"
+        to={`/learning/collection/${collection.id}`}
         title={collection.title}
         type={collection.type}
         tags={collection.tags.map((t) => ({

--- a/apps/learner/src/routes/(protected)/(core)/learning/collection/[id]/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/(core)/learning/collection/[id]/+page.server.ts
@@ -13,9 +13,6 @@ export const load: PageServerLoad = async (event) => {
     throw redirect(303, '/login');
   }
 
-  const collectionId = BigInt(event.params.id);
-  const userId = BigInt(user.id);
-
   const collection = await db.collection.findUnique({
     where: { id: BigInt(event.params.id) },
     select: {
@@ -23,19 +20,11 @@ export const load: PageServerLoad = async (event) => {
     },
   });
 
-  console.log('Fetched Collection:', collection);
-
   if (!collection) {
     throw error(404);
   }
 
   const learningJourneys = await db.learningJourney.findMany({
-    where: {
-      userId: userId,
-      learningUnit: {
-        collectionId: collectionId,
-      },
-    },
     select: {
       id: true,
       isCompleted: true,
@@ -55,6 +44,12 @@ export const load: PageServerLoad = async (event) => {
             },
           },
         },
+      },
+    },
+    where: {
+      userId: BigInt(user.id),
+      learningUnit: {
+        collectionId: BigInt(event.params.id),
       },
     },
   });

--- a/apps/learner/src/routes/(protected)/(core)/learning/collection/[id]/+page@(protected).svelte
+++ b/apps/learner/src/routes/(protected)/(core)/learning/collection/[id]/+page@(protected).svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { ArrowLeft } from '@lucide/svelte';
 
-  import { LearningUnit, type LearningUnitProps } from '$lib/components/LearningUnit/index.js';
-  import { IsWithinViewport } from '$lib/helpers/index.js';
+  import { LearningUnit } from '$lib/components/LearningUnit/index.js';
+  import { IsWithinViewport, tagCodeToBadgeVariant } from '$lib/helpers/index.js';
 
   let target = $state<HTMLElement | null>(null);
 
@@ -29,7 +29,7 @@
           <ArrowLeft />
         </a>
 
-        <span class="text-xl font-medium">SEN peer support</span>
+        <span class="text-xl font-medium">{data.collection.title}</span>
       </div>
     </div>
   </div>
@@ -46,8 +46,11 @@
     <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
       {#each data.learningUnits as learningUnit (learningUnit.id)}
         <LearningUnit
-          to={learningUnit.to}
-          tags={learningUnit.tags as LearningUnitProps['tags']}
+          to="/content/{learningUnit.id}"
+          tags={learningUnit.tags.map((t) => ({
+            variant: tagCodeToBadgeVariant(t.code),
+            content: t.label,
+          }))}
           title={learningUnit.title}
           createdat={learningUnit.createdAt}
           createdby={learningUnit.createdBy}
@@ -64,8 +67,11 @@
     <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
       {#each data.learningUnits as learningUnit (learningUnit.id)}
         <LearningUnit
-          to={learningUnit.to}
-          tags={learningUnit.tags as LearningUnitProps['tags']}
+          to="/content/{learningUnit.id}"
+          tags={learningUnit.tags.map((t) => ({
+            variant: tagCodeToBadgeVariant(t.code),
+            content: t.label,
+          }))}
           title={learningUnit.title}
           createdat={learningUnit.createdAt}
           createdby={learningUnit.createdBy}

--- a/apps/learner/src/routes/(protected)/(core)/learning/collection/[id]/+page@(protected).svelte
+++ b/apps/learner/src/routes/(protected)/(core)/learning/collection/[id]/+page@(protected).svelte
@@ -46,7 +46,7 @@
     <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
       {#each data.journeys.inProgress as journey (journey.id)}
         <LearningUnit
-          to="/content/{journey.id}"
+          to="/unit/{journey.unitId}"
           tags={journey.tags.map((t) => ({
             variant: tagCodeToBadgeVariant(t.code),
             content: t.label,
@@ -65,9 +65,9 @@
     </div>
 
     <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
-      {#each data.journeys.completed as journey (journey.id)}
+      {#each data.journeys.isCompleted as journey (journey.id)}
         <LearningUnit
-          to="/content/{journey.id}"
+          to="/unit/{journey.unitId}"
           tags={journey.tags.map((t) => ({
             variant: tagCodeToBadgeVariant(t.code),
             content: t.label,

--- a/apps/learner/src/routes/(protected)/(core)/learning/collection/[id]/+page@(protected).svelte
+++ b/apps/learner/src/routes/(protected)/(core)/learning/collection/[id]/+page@(protected).svelte
@@ -29,7 +29,7 @@
           <ArrowLeft />
         </a>
 
-        <span class="text-xl font-medium">{data.collection.title}</span>
+        <span class="text-xl font-medium">{data.title}</span>
       </div>
     </div>
   </div>
@@ -44,16 +44,16 @@
     </div>
 
     <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
-      {#each data.learningUnits as learningUnit (learningUnit.id)}
+      {#each data.journeys.inProgress as journey (journey.id)}
         <LearningUnit
-          to="/content/{learningUnit.id}"
-          tags={learningUnit.tags.map((t) => ({
+          to="/content/{journey.id}"
+          tags={journey.tags.map((t) => ({
             variant: tagCodeToBadgeVariant(t.code),
             content: t.label,
           }))}
-          title={learningUnit.title}
-          createdat={learningUnit.createdAt}
-          createdby={learningUnit.createdBy}
+          title={journey.title}
+          createdat={journey.createdAt}
+          createdby={journey.createdBy}
         />
       {/each}
     </div>
@@ -65,16 +65,16 @@
     </div>
 
     <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
-      {#each data.learningUnits as learningUnit (learningUnit.id)}
+      {#each data.journeys.completed as journey (journey.id)}
         <LearningUnit
-          to="/content/{learningUnit.id}"
-          tags={learningUnit.tags.map((t) => ({
+          to="/content/{journey.id}"
+          tags={journey.tags.map((t) => ({
             variant: tagCodeToBadgeVariant(t.code),
             content: t.label,
           }))}
-          title={learningUnit.title}
-          createdat={learningUnit.createdAt}
-          createdby={learningUnit.createdBy}
+          title={journey.title}
+          createdat={journey.createdAt}
+          createdby={journey.createdBy}
         />
       {/each}
     </div>


### PR DESCRIPTION
## 🚀 Summary

This update enhances the `learning` collection feature by adding a server-side `load` function to fetch collection data and learning units dynamically, with error handling for missing collections. The route has been updated from `/usercollection/:id `to `/learning/collection/:id`, and the collection title is now rendered dynamically on the frontend. 

## ✏️ Changes

- Added a new server-side loader to fetch collection and learning unit data dynamically.
- Changed the route structure from `/usercollection/:id` to `/learning/collection/:id` for a more intuitive hierarchy.
- Made the collection title dynamic, pulling data directly from the database.
- Implemented a (protected) layout for the page to break out of all the layouts and only inherit from (protected) layout.

Ref: https://svelte.dev/tutorial/kit/breaking-out-of-layouts

