### PR TITLE
feat(learner): add dynamic`learning` content data

### DIFF
--- a/apps/learner/src/lib/components/Collection/Collection.svelte
+++ b/apps/learner/src/lib/components/Collection/Collection.svelte
@@ -52,7 +52,10 @@
       </div>
 
       <div class="flex flex-col">
-        <span class="text-sm">{numberofpodcasts} podcasts</span>
+        <span class="text-sm">
+          {numberofpodcasts}
+          {numberofpodcasts === 1 ? 'podcast' : 'podcasts'}
+        </span>
       </div>
     </div>
   </div>

--- a/apps/learner/src/routes/(protected)/(core)/learning/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/(core)/learning/+page.server.ts
@@ -1,3 +1,5 @@
+import { error } from '@sveltejs/kit';
+
 import { db } from '$lib/server/db';
 
 import type { PageServerLoad } from './$types';
@@ -29,6 +31,10 @@ export const load: PageServerLoad = async () => {
       },
     },
   });
+
+  if (collections.length === 0) {
+    throw error(404);
+  }
 
   return {
     collections: collections.map((collection) => ({

--- a/apps/learner/src/routes/(protected)/(core)/learning/+page.svelte
+++ b/apps/learner/src/routes/(protected)/(core)/learning/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Collection, type CollectionProps } from '$lib/components/Collection/index.js';
+  import { Collection } from '$lib/components/Collection/index.js';
   import { tagCodeToBadgeVariant } from '$lib/helpers/index.js';
 
   const { data } = $props();
@@ -12,16 +12,18 @@
 
   <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
     {#each data.collections as collection (collection.id)}
-      <Collection
-        to={`/usercollection/${collection.id}`}
-        title={collection.title}
-        type={collection.type as CollectionProps['type']}
-        tags={collection.tags.map((t) => ({
-          variant: tagCodeToBadgeVariant(t.code),
-          content: t.label,
-        }))}
-        numberofpodcasts={collection.numberofpodcasts}
-      />
+      {#if collection.numberOfPodcasts > 0}
+        <Collection
+          to="/collection/{collection.id}"
+          title={collection.title}
+          type={collection.type}
+          tags={collection.tags.map((t) => ({
+            variant: tagCodeToBadgeVariant(t.code),
+            content: t.label,
+          }))}
+          numberofpodcasts={collection.numberOfPodcasts}
+        />
+      {/if}
     {/each}
   </div>
 </main>


### PR DESCRIPTION
## 🚀 Summary

This update enhances the `learning` page by adding a server-side `load` function to fetch the `collection` data dynamically, with error handling for missing collections. The display logic for `numberofpodcasts` is also updated. The display now uses a ternary operator to handle singular and plural forms, ensuring correct grammatical output. 

## ✏️ Changes

  - Updated `numberofpodcasts` display logic to use `{numberofpodcasts === 1 ? 'podcast' : 'podcasts'}` for proper singular/plural handling.
  - Enhanced the server-side `load` function to fetch and display updated learning page content data dynamically.
  - Add error handling when `collections length === 0`.
