### PR TITLE
feat: customize the Tailwind typography prose-slate for chat markdown UI

### DIFF
--- a/apps/learner/src/app.css
+++ b/apps/learner/src/app.css
@@ -12,3 +12,20 @@
 @theme {
   --font-geist: 'Geist', sans-serif;
 }
+
+@utility prose-slate {
+  --tw-prose-body: var(--color-slate-950);
+  --tw-prose-headings: var(--color-slate-950);
+  --tw-prose-links: var(--color-slate-950);
+  --tw-prose-bold: var(--color-slate-950);
+  --tw-prose-counters: var(--color-slate-950);
+  --tw-prose-bullets: var(--color-slate-950);
+  --tw-prose-hr: var(--color-slate-300);
+  --tw-prose-quotes: var(--color-slate-950);
+  --tw-prose-quote-borders: var(--color-slate-300);
+  --tw-prose-code: var(--color-slate-950);
+  --tw-prose-pre-code: var(--color-slate-200);
+  --tw-prose-pre-bg: var(--color-slate-800);
+  --tw-prose-th-borders: var(--color-slate-300);
+  --tw-prose-td-borders: var(--color-slate-200);
+}


### PR DESCRIPTION
Closes #235 

## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

This pull request aligns the Tailwind prose color scheme. The Tailwind prose-slate color configuration aligns the element colors to our existing UI.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Override the tailwind `prose-slate` color configuration.