### PR TITLE
ci: add missing permission to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## 🚀 Summary

This PR add missing permission to the release workflow.

## ✏️ Changes

- Added `id_token: write` to release workflow permission
