### PR TITLE
release: v0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.0.2 (2025-09-30)
+
+### CI 🤖
+
+- ci: add missing permission to release workflow ([#245](https://github.com/String-sg/onward/pull/245)) ([b774ef7](https://github.com/String-sg/onward/commit/b774ef7b336ad5c13e13c8a767749aac9b8f57d3))
+
 ## 0.0.1 (2025-09-30)
 
 ### Experimental 🧪

--- a/apps/learner/package.json
+++ b/apps/learner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onward/learner",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## 0.0.2 (2025-09-30)

### CI 🤖

- ci: add missing permission to release workflow ([#245](https://github.com/String-sg/onward/pull/245)) ([b774ef7](https://github.com/String-sg/onward/commit/b774ef7b336ad5c13e13c8a767749aac9b8f57d3))