### PR TITLE
feat(learner): Update quiz completion status after finishing quiz

### DIFF
--- a/apps/learner/prisma/migrations/20251002063500_add_user_learning_unit_constraint_to_learning_journey/migration.sql
+++ b/apps/learner/prisma/migrations/20251002063500_add_user_learning_unit_constraint_to_learning_journey/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[user_id,learning_unit_id]` on the table `learning_journeys` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "learning_journeys_user_id_learning_unit_id_key" ON "public"."learning_journeys"("user_id", "learning_unit_id");

--- a/apps/learner/prisma/schema.prisma
+++ b/apps/learner/prisma/schema.prisma
@@ -92,6 +92,7 @@ model LearningJourney {
   user         User         @relation(fields: [userId], references: [id])
   learningUnit LearningUnit @relation(fields: [learningUnitId], references: [id])
 
+  @@unique([userId, learningUnitId])
   @@map("learning_journeys")
 }
 

--- a/apps/learner/src/routes/(protected)/unit/[id]/quiz/+page.server.ts
+++ b/apps/learner/src/routes/(protected)/unit/[id]/quiz/+page.server.ts
@@ -1,8 +1,13 @@
 import { error, redirect } from '@sveltejs/kit';
 
-import { db, type LearningUnitFindUniqueArgs, type LearningUnitGetPayload } from '$lib/server/db';
+import {
+  db,
+  type LearningJourneyUpsertArgs,
+  type LearningUnitFindUniqueArgs,
+  type LearningUnitGetPayload,
+} from '$lib/server/db';
 
-import type { PageServerLoad } from './$types';
+import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async (event) => {
   const logger = event.locals.logger.child({ handler: 'page_quiz' });
@@ -70,4 +75,36 @@ export const load: PageServerLoad = async (event) => {
     type: learningUnit.collection.type,
     label: learningUnit.collection.tags[0]?.tag.label,
   };
+};
+
+export const actions: Actions = {
+  updateQuizStatus: async (event) => {
+    const logger = event.locals.logger.child({ handler: 'page_update_quiz' });
+
+    const { user } = event.locals.session;
+    if (!user) {
+      logger.warn('User not authenticated');
+      return redirect(303, '/login');
+    }
+
+    const learningJourneyArgs = {
+      update: { isCompleted: true },
+      where: {
+        userId_learningUnitId: { userId: BigInt(user.id), learningUnitId: BigInt(event.params.id) },
+      },
+      create: {
+        userId: BigInt(user.id),
+        learningUnitId: BigInt(event.params.id),
+        isCompleted: true,
+        lastCheckpoint: 0,
+      },
+    } satisfies LearningJourneyUpsertArgs;
+
+    try {
+      await db.learningJourney.upsert(learningJourneyArgs);
+    } catch (err) {
+      logger.error({ err }, 'Failed to update quiz completion status');
+      throw error(500);
+    }
+  },
 };

--- a/apps/learner/src/routes/(protected)/unit/[id]/quiz/+page.svelte
+++ b/apps/learner/src/routes/(protected)/unit/[id]/quiz/+page.svelte
@@ -31,12 +31,16 @@
     isFeedbackModalOpen = !isFeedbackModalOpen;
   };
 
-  const handleContinueClick = () => {
+  const handleContinueClick = async () => {
     const isLastQuestionAnswer = currentQuestionAnswerIndex === data.questionAnswers.length - 1;
 
     isFeedbackModalOpen = false;
 
     if (isLastQuestionAnswer) {
+      await fetch('?/updateQuizStatus', {
+        method: 'POST',
+        body: new FormData(),
+      });
       isCompletionModalOpen = true;
       return;
     }


### PR DESCRIPTION
Closes #249 

## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->
This PR aims to update the learning journey status to completed when a user finishes the quiz. This is so that the learning journey can capture the progress of the user and what the user has learnt thus far.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->
- Added unique constraints on `userId` and `learningUnitId` pair
- Update status once a user completes the final question of the quiz