### PR TITLE
feat: add S3 proxy endpoint for podcasts

### DIFF
--- a/apps/learner/src/lib/server/s3.ts
+++ b/apps/learner/src/lib/server/s3.ts
@@ -1,4 +1,12 @@
-import { ListObjectsV2Command, S3Client } from '@aws-sdk/client-s3';
+import { Readable } from 'node:stream';
+
+import {
+  GetObjectCommand,
+  NoSuchKey,
+  NotFound,
+  S3Client,
+  S3ServiceException,
+} from '@aws-sdk/client-s3';
 
 import { env } from '$env/dynamic/private';
 
@@ -18,6 +26,83 @@ const client =
       })
     : new S3Client();
 
-export const listObjects = async () => {
-  return await client.send(new ListObjectsV2Command({ Bucket: BUCKET }));
-};
+/**
+ * Retrieves an object from S3 with the given key. If the object does not exist, `null` is returned.
+ * If the range is not satisfiable, a {@link RangeNotSatisfiableError} is thrown.
+ *
+ * @param key - The key of the object to get.
+ * @param opts.range - An optional range to retrieve a portion of the object.
+ * @returns The object from S3, or `null` if the object does not exist.
+ */
+export async function getPodcastObject(
+  key: string,
+  opts: { range?: string | null } = {},
+): Promise<{
+  stream: ReadableStream;
+  headers: Record<string, string>;
+} | null> {
+  try {
+    const cmd = new GetObjectCommand({ Bucket: BUCKET, Key: key, Range: opts.range ?? undefined });
+    const res = await client.send(cmd);
+
+    if (!res.Body || !(res.Body instanceof Readable)) {
+      return null;
+    }
+
+    const stream = Readable.toWeb(res.Body);
+    if (!(stream instanceof ReadableStream)) {
+      return null;
+    }
+
+    const headers: Record<string, string> = {};
+    if (res.ContentType) {
+      headers['Content-Type'] = res.ContentType;
+    }
+    if (res.ContentLength) {
+      headers['Content-Length'] = String(res.ContentLength);
+    }
+    if (res.AcceptRanges) {
+      headers['Accept-Ranges'] = res.AcceptRanges;
+    }
+    if (res.ContentRange) {
+      headers['Content-Range'] = res.ContentRange;
+    }
+    if (res.LastModified) {
+      headers['Last-Modified'] = res.LastModified.toUTCString();
+    }
+    if (res.ETag) {
+      headers['ETag'] = res.ETag;
+    }
+
+    return { stream, headers };
+  } catch (err) {
+    if (err instanceof NoSuchKey || err instanceof NotFound) {
+      return null;
+    }
+    if (err instanceof S3ServiceException && err.$metadata.httpStatusCode === 416) {
+      throw new RangeNotSatisfiableError();
+    }
+
+    throw err;
+  }
+}
+
+/**
+ * The base class for all S3 errors.
+ */
+export class BaseError extends Error {
+  constructor(message: string) {
+    super(message);
+
+    this.name = this.constructor.name;
+  }
+}
+
+/**
+ * Thrown when a requested range is not satisfiable.
+ */
+export class RangeNotSatisfiableError extends BaseError {
+  constructor() {
+    super('Requested range not satisfiable');
+  }
+}

--- a/apps/learner/src/routes/(protected)/podcasts/[...key]/+server.ts
+++ b/apps/learner/src/routes/(protected)/podcasts/[...key]/+server.ts
@@ -1,0 +1,45 @@
+import { type RequestHandler, text } from '@sveltejs/kit';
+
+import { getPodcastObject, RangeNotSatisfiableError } from '$lib/server/s3.js';
+
+const TEMPLATE = '<html><body><pre>%s</pre></body></html>';
+const INVALID_REQUEST_BODY = TEMPLATE.replace('%s', 'Invalid request');
+const REQUEST_RANGE_NOT_SATISFIED_BODY = TEMPLATE.replace('%s', 'Requested range not satisfiable');
+const SOMETHING_WENT_WRONG_BODY = TEMPLATE.replace('%s', 'Something went wrong');
+
+export const GET: RequestHandler = async (event) => {
+  const logger = event.locals.logger.child({ handler: 'api_get_podcast' });
+
+  const { user } = event.locals.session;
+  if (!user) {
+    logger.warn('User not authenticated');
+    return text(INVALID_REQUEST_BODY, { status: 400 });
+  }
+
+  const range = event.request.headers.get('range');
+
+  let podcast: Awaited<ReturnType<typeof getPodcastObject>> | null = null;
+  try {
+    podcast = await getPodcastObject(`/podcasts/${event.params.key}`, { range });
+    if (!podcast) {
+      return text(INVALID_REQUEST_BODY, { status: 400 });
+    }
+  } catch (err) {
+    if (err instanceof RangeNotSatisfiableError) {
+      return text(REQUEST_RANGE_NOT_SATISFIED_BODY, { status: 416 });
+    }
+
+    logger.error({ err }, 'Failed to retrieve podcast');
+    return text(SOMETHING_WENT_WRONG_BODY, { status: 500 });
+  }
+
+  const headers = new Headers({ 'Cache-Control': 'private, max-age=0, must-revalidate' });
+  for (const [key, value] of Object.entries(podcast.headers)) {
+    headers.set(key, value);
+  }
+
+  return new Response(podcast.stream, {
+    status: range ? 206 : 200,
+    headers,
+  });
+};


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

This PR introduces a new endpoint `/podcasts/[...key]` that proxies requests to S3. It enables authenticated users to stream podcast audio directly from S3 through our server, ensuring proper access control and support for range-based playback.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Refactored `routeProtectionHandle` to use an explicit whitelist instead of a blacklist
- Added `getPodcastObject` to retrieve podcast from S3
- Added new endpoint`/podcasts/[...key]` to proxy requests to S3
- Added support for range requests, allowing browsers to seek and download specific portions of podcast audio