### PR TITLE
fix: remove unnecessary slash in the key when getting podcast object

### DIFF
--- a/src/routes/(protected)/podcasts/[...key]/+server.ts
+++ b/src/routes/(protected)/podcasts/[...key]/+server.ts
@@ -20,7 +20,7 @@ export const GET: RequestHandler = async (event) => {
 
   let podcast: Awaited<ReturnType<typeof getPodcastObject>> | null = null;
   try {
-    podcast = await getPodcastObject(`/podcasts/${event.params.key}`, { range });
+    podcast = await getPodcastObject(`podcasts/${event.params.key}`, { range });
     if (!podcast) {
       return text(INVALID_REQUEST_BODY, { status: 400 });
     }


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

This PR fixes the issue where S3 is returning 404 when trying to proxy the podcast object. It was due to unnecessary slash in the key when getting the podcast object files from S3.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Removed unnecessary slash in the key when getting podcast object from S3
