### PR TITLE
fix: patch `vite-imagetools` to use synchronous file writes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ ENV PRISMA_SKIP_POSTINSTALL_GENERATE=true
 
 # Fetch all dependencies into the virtual store.
 COPY pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY patches ./patches
 RUN pnpm fetch
 
 COPY . .

--- a/patches/vite-imagetools.patch
+++ b/patches/vite-imagetools.patch
@@ -1,0 +1,21 @@
+diff --git a/dist/index.js b/dist/index.js
+index 4867f5f7698961141470465ae506a93c05341345..7e93b8615e9cadb3601bc9f25d2f46501514713b 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -1,6 +1,6 @@
+ import { basename, extname } from 'node:path';
+ import { relative } from 'node:path/posix';
+-import { mkdirSync, createReadStream, statSync } from 'node:fs';
++import { mkdirSync, createReadStream, statSync, writeFileSync } from 'node:fs';
+ import { opendir, stat, rm, writeFile, readFile } from 'node:fs/promises';
+ import { normalizePath } from 'vite';
+ import { builtins, builtinOutputFormats, getMetadata, parseURL, extractEntries, resolveConfigs, generateTransforms, applyTransforms, urlFormat } from 'imagetools-core';
+@@ -123,7 +123,7 @@ function imagetools(userOptions = {}) {
+                     const res = await applyTransforms(transforms, img, pluginOptions.removeMetadata);
+                     metadata = res.metadata;
+                     if (cacheOptions.enabled) {
+-                        await writeFile(`${cacheOptions.dir}/${id}`, await res.image.toBuffer());
++                        writeFileSync(`${cacheOptions.dir}/${id}`, await res.image.toBuffer());
+                     }
+                     else {
+                         image = res.image;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  vite-imagetools:
+    hash: 40ee8f08a912b0823d1a8e3080e47e0baab3895ae9ed8e7bcf5e099680d18084
+    path: patches/vite-imagetools.patch
+
 importers:
 
   .:
@@ -4284,7 +4289,7 @@ snapshots:
       svelte: 5.38.0
       svelte-parse-markup: 0.1.5(svelte@5.38.0)
       vite: 7.1.1(@types/node@24.0.3)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5)(yaml@2.8.0)
-      vite-imagetools: 8.0.0(rollup@4.46.2)
+      vite-imagetools: 8.0.0(patch_hash=40ee8f08a912b0823d1a8e3080e47e0baab3895ae9ed8e7bcf5e099680d18084)(rollup@4.46.2)
       zimmerframe: 1.1.2
     transitivePeerDependencies:
       - rollup
@@ -5942,7 +5947,7 @@ snapshots:
 
   uuid@9.0.1: {}
 
-  vite-imagetools@8.0.0(rollup@4.46.2):
+  vite-imagetools@8.0.0(patch_hash=40ee8f08a912b0823d1a8e3080e47e0baab3895ae9ed8e7bcf5e099680d18084)(rollup@4.46.2):
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.46.2)
       imagetools-core: 8.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,6 @@ onlyBuiltDependencies:
   - prisma
   - protobufjs
   - sharp
+
+patchedDependencies:
+  vite-imagetools: patches/vite-imagetools.patch


### PR DESCRIPTION
Fixes #281 

## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

Asynchronous file writes in `vite-imagetools` caching may cause intermittent incorrect assets output during build. This patch switches to synchronous writes to verify if it resolves the issue.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Added a patch to `vite-imagetools` to use synchronous file writes
