### PR TITLE
fix: correct naming for action

### DIFF
--- a/src/routes/(protected)/unit/[id]/quiz/+page.server.ts
+++ b/src/routes/(protected)/unit/[id]/quiz/+page.server.ts
@@ -80,7 +80,7 @@ export const load: PageServerLoad = async (event) => {
 };
 
 export const actions: Actions = {
-  updateLearningUnitCompletionStatus: async (event) => {
+  updateLJCompletionStatus: async (event) => {
     const logger = event.locals.logger.child({
       handler: 'page_action_update_learning_unit_completion_status',
     });


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->
This PR fixes an issue with the naming of the action in quiz when the quiz is completed. There's a desync in the naming between page and server hence when user clicks on complete quiz it will throw an error

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->
- correct action naming to `updateLJCompletionStatus`