### PR TITLE
chore: customize width for Learning Unit content summary markdown

### DIFF
--- a/src/routes/(protected)/unit/[id]/+page.svelte
+++ b/src/routes/(protected)/unit/[id]/+page.svelte
@@ -157,21 +157,14 @@
   <div class="flex flex-col gap-y-4">
     <div
       class={[
-        'max-h-28 overflow-hidden mask-b-from-10%',
-        isExpanded && 'max-h-full mask-b-from-100%',
+        'prose prose-slate line-clamp-4 max-h-28 max-w-none mask-b-from-10% text-lg',
+        isExpanded && 'line-clamp-none max-h-full mask-b-from-100%',
       ]}
     >
-      <p
-        class={[
-          'prose prose-slate line-clamp-4 max-w-full text-lg',
-          isExpanded && 'line-clamp-none',
-        ]}
-      >
-        {#if browser}
-          <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-          {@html DOMPurify.sanitize(marked.parse(data.summary, { async: false }))}
-        {/if}
-      </p>
+      {#if browser}
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+        {@html DOMPurify.sanitize(marked.parse(data.summary, { async: false }))}
+      {/if}
     </div>
 
     {#if !isExpanded}


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

This pull request solves the Learning Unit content page markdown text not utilizing the full width of it's container.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Added `max-w-full` to the summary prose container.