### PR TITLE
fix: reposition badge on quiz

### DIFF
--- a/src/routes/(protected)/unit/[id]/quiz/+page.svelte
+++ b/src/routes/(protected)/unit/[id]/quiz/+page.svelte
@@ -73,10 +73,6 @@
       >
         <ArrowLeft />
       </a>
-
-      <Badge variant="slate">
-        Question {currentQuestionAnswerIndex + 1} of {data.questionAnswers.length}
-      </Badge>
     </div>
   </div>
 </header>
@@ -85,6 +81,10 @@
 
 <main class="relative mx-auto flex min-h-svh max-w-5xl flex-col gap-y-10 px-4 pt-23 pb-3">
   <div class="flex flex-1 flex-col gap-y-2">
+    <Badge variant="slate">
+      Question {currentQuestionAnswerIndex + 1} of {data.questionAnswers.length}
+    </Badge>
+
     {#each data.questionAnswers as q, qi (q.id)}
       <div class={['flex flex-col gap-y-4', currentQuestionAnswerIndex !== qi && 'hidden']}>
         <span id="question-{qi}" class="text-xl font-medium">{q.question}</span>


### PR DESCRIPTION
Closes #309 

## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

This PR repositions the badge to above the question, since as per issue the badge is not a page title / breadcrumb