### PR TITLE
fix: chat window for IOS Safari

### DIFF
--- a/src/lib/components/ChatView/ChatView.svelte
+++ b/src/lib/components/ChatView/ChatView.svelte
@@ -216,7 +216,7 @@
         <div bind:this={target} class="absolute inset-x-0 top-0 h-px"></div>
 
         <!-- TODO: temporary hardcode height for now. To relook at how to set this height without hardcoding an arbitrary height -->
-        <div class="h-[calc(100vh-180px)] overflow-y-auto px-4 pt-3">
+        <div class="h-[calc(100svh-180px)] overflow-y-auto px-4 pt-3">
           <div class="flex flex-col gap-y-4">
             {#if messages.length === 0}
               <span class="text-xl font-medium">


### PR DESCRIPTION
Closes #301 

## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

This pull request fixes the chat window view for IOS Safari issue. 

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Use `svh` instead of `vh` for the chat window container size.