### PR TITLE
feat: track podcast play event

### DIFF
--- a/src/lib/helpers/analytics.ts
+++ b/src/lib/helpers/analytics.ts
@@ -1,0 +1,47 @@
+import { browser } from '$app/environment';
+import { env } from '$env/dynamic/public';
+
+declare global {
+  interface Window {
+    gtag: (command: string, ...args: unknown[]) => void;
+    dataLayer: unknown[];
+  }
+}
+
+/**
+ * Initialises the Google Analytics script.
+ */
+export function initAnalytics() {
+  if (!browser) {
+    return;
+  }
+
+  // Load gtag script
+  const script = document.createElement('script');
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${env.PUBLIC_GOOGLE_ANALYTICS_ID}`;
+  document.head.appendChild(script);
+
+  window.dataLayer = window.dataLayer || [];
+
+  window.gtag = (...args) => {
+    window.dataLayer.push(args);
+  };
+
+  window.gtag('js', new Date());
+  window.gtag('config', env.PUBLIC_GOOGLE_ANALYTICS_ID);
+}
+
+/**
+ * Tracks when a podcast is played.
+ * @param learningUnitId - The ID of the learning unit that was played.
+ */
+export function trackPodcastPlay(learningUnitId: bigint) {
+  if (!browser) {
+    return;
+  }
+
+  window.gtag('event', 'podcast_play', {
+    learning_unit_id: learningUnitId,
+  });
+}

--- a/src/lib/helpers/index.ts
+++ b/src/lib/helpers/index.ts
@@ -1,3 +1,4 @@
+export * from './analytics.js';
 export * from './format.js';
 export * from './is-within-viewport.svelte.js';
 export * from './mapping.js';

--- a/src/routes/(protected)/unit/[id]/+page.svelte
+++ b/src/routes/(protected)/unit/[id]/+page.svelte
@@ -9,7 +9,7 @@
   import { page } from '$app/state';
   import { Badge } from '$lib/components/Badge/index.js';
   import { Button, LinkButton } from '$lib/components/Button/index.js';
-  import { IsWithinViewport, tagCodeToBadgeVariant } from '$lib/helpers/index.js';
+  import { IsWithinViewport, tagCodeToBadgeVariant, trackPodcastPlay } from '$lib/helpers/index.js';
   import { Player } from '$lib/states/index.js';
 
   const { data } = $props();
@@ -43,6 +43,8 @@
   };
 
   const handlePlay = () => {
+    trackPodcastPlay(data.id);
+
     player.play({
       id: data.id,
       tags: data.tags,
@@ -56,6 +58,8 @@
   };
 
   const handleResume = () => {
+    trackPodcastPlay(data.id);
+
     if (!isActive) {
       const initialSeekTime = lastCheckpoint;
       player.play(

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,6 +2,10 @@
   import '../app.css';
 
   const { children } = $props();
+
+  import { initAnalytics } from '$lib/helpers/index.js';
+
+  initAnalytics();
 </script>
 
 {@render children()}


### PR DESCRIPTION
## 🚀 Summary

Add analytics for podcast playback by emitting a GA event when users start playing a unit’s audio. This improves visibility into engagement with audio content.

## ✏️ Changes

1. Added `src/lib/helpers/analytics.ts` with a trackEvent wrapper and a specific `"podcast_play"` event utility.
2. Re-exported analytics helpers via `src/lib/helpers/index.ts`.
3. Instrumented `src/routes/(protected)/unit/[id]/+page.svelte` to send a `"podcast_play"` event when playback begins, including relevant unit metadata.
4. Ensured GA initialization/use hooks exist in `src/routes/+layout.svelte` so client-side events are available after navigation.