### PR TITLE
fix: add default for updated_at column for learning unit sources

### DIFF
--- a/prisma/migrations/20251015160716_update_default_updated_at_column_learning_unit_sources/migration.sql
+++ b/prisma/migrations/20251015160716_update_default_updated_at_column_learning_unit_sources/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."learning_unit_sources" ALTER COLUMN "updated_at" SET DEFAULT CURRENT_TIMESTAMP;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -104,7 +104,7 @@ model LearningUnitSentiments {
 model LearningUnitSources {
   id        BigInt   @id @default(autoincrement()) @map("id")
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
-  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+  updatedAt DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(3)
 
   // Domain-Specific Fields.
   title     String @map("title")


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->
This PR fixes a missing default on `updated_at` column on `LearningUnitSources` table

