### PR TITLE
feat: set reasoning effort to `minimal`

### DIFF
--- a/src/routes/api/messages/+server.ts
+++ b/src/routes/api/messages/+server.ts
@@ -118,6 +118,7 @@ export const POST: RequestHandler = async (event) => {
       },
     ],
     stream: true,
+    reasoning_effort: 'minimal',
   });
 
   const encoder = new TextEncoder();


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

This pull request sets the reasoning effort config of gpt-5-nano to the lowest (minimal) because we don't need the reasoning effort to be high, especially for RAG chatbots.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Added the `reasoning_effort` property to minimal