### PR TITLE
fix: always remove `overflow` property when closing modal

### DIFF
--- a/src/lib/components/Modal/Modal.svelte
+++ b/src/lib/components/Modal/Modal.svelte
@@ -52,14 +52,12 @@
   }: Props = $props();
 
   $effect.pre(() => {
-    const prev = document.body.style.getPropertyValue('overflow');
-
     if (isopen) {
       document.body.style.setProperty('overflow', 'hidden');
     }
 
     return () => {
-      document.body.style.setProperty('overflow', prev);
+      document.body.style.removeProperty('overflow');
     };
   });
 


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

When user completed the quiz, the feedback and completed modal triggers the `$effect.pre` in the `Modal` component which cause it unable to scroll after closing all the modals. This PR will always remove the `overflow` property on the document body whenever a modal closes.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Always remove `overflow` property whenever the `Modal` unmounts
