### PR TITLE
feat: hide empty progress sections when no units to display

### DIFF
--- a/src/routes/(protected)/(core)/learning/collection/[id]/+page@(protected).svelte
+++ b/src/routes/(protected)/(core)/learning/collection/[id]/+page@(protected).svelte
@@ -45,45 +45,49 @@
     </p>
   </div>
 
-  <div class="flex flex-col gap-y-3">
-    <div class="px-2">
-      <span class="text-xl font-semibold">In Progress</span>
-    </div>
+  {#if data.journeys.inProgress.length > 0}
+    <div class="flex flex-col gap-y-3">
+      <div class="px-2">
+        <span class="text-xl font-semibold">In Progress</span>
+      </div>
 
-    <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
-      {#each data.journeys.inProgress as journey (journey.id)}
-        <LearningUnit
-          to="/unit/{journey.unitId}"
-          tags={journey.tags.map((t) => ({
-            variant: tagCodeToBadgeVariant(t.code),
-            content: t.label,
-          }))}
-          title={journey.title}
-          createdat={journey.createdAt}
-          createdby={journey.createdBy}
-        />
-      {/each}
+      <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
+        {#each data.journeys.inProgress as journey (journey.id)}
+          <LearningUnit
+            to="/unit/{journey.unitId}"
+            tags={journey.tags.map((t) => ({
+              variant: tagCodeToBadgeVariant(t.code),
+              content: t.label,
+            }))}
+            title={journey.title}
+            createdat={journey.createdAt}
+            createdby={journey.createdBy}
+          />
+        {/each}
+      </div>
     </div>
-  </div>
+  {/if}
 
-  <div class="flex flex-col gap-y-3">
-    <div class="px-2">
-      <span class="text-xl font-semibold">Completed</span>
-    </div>
+  {#if data.journeys.isCompleted.length > 0}
+    <div class="flex flex-col gap-y-3">
+      <div class="px-2">
+        <span class="text-xl font-semibold">Completed</span>
+      </div>
 
-    <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
-      {#each data.journeys.isCompleted as journey (journey.id)}
-        <LearningUnit
-          to="/unit/{journey.unitId}"
-          tags={journey.tags.map((t) => ({
-            variant: tagCodeToBadgeVariant(t.code),
-            content: t.label,
-          }))}
-          title={journey.title}
-          createdat={journey.createdAt}
-          createdby={journey.createdBy}
-        />
-      {/each}
+      <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
+        {#each data.journeys.isCompleted as journey (journey.id)}
+          <LearningUnit
+            to="/unit/{journey.unitId}"
+            tags={journey.tags.map((t) => ({
+              variant: tagCodeToBadgeVariant(t.code),
+              content: t.label,
+            }))}
+            title={journey.title}
+            createdat={journey.createdAt}
+            createdby={journey.createdBy}
+          />
+        {/each}
+      </div>
     </div>
-  </div>
+  {/if}
 </main>


### PR DESCRIPTION
Closes https://github.com/String-sg/onward/issues/350

## 🚀 Summary

This PR improves the user experience in the collection view by hiding empty "In Progress" and "Completed" sections when there are no learning units to display. Previously, these section headers would always show even when empty, creating visual clutter and confusion for users.

## ✏️ Changes

- Added conditional rendering for "In Progress" section - only displays when `data.journeys.inProgress.length > 0`
- Added conditional rendering for "Completed" section - only displays when `data.journeys.isCompleted.length > 0`
- Wrapped both sections with Svelte `{#if}` blocks to hide entire sections (including headers) when empty
- Maintains existing functionality while providing cleaner UI when no content is available