### PR TITLE
fix: ensure `dataLayer` and `gtag` are defined before loading the `gtag` script

### DIFF
--- a/src/lib/helpers/analytics.ts
+++ b/src/lib/helpers/analytics.ts
@@ -16,17 +16,15 @@ export function initAnalytics() {
     return;
   }
 
-  // Load gtag script
+  window.dataLayer = window.dataLayer || [];
+  window.gtag = (...args) => {
+    window.dataLayer.push(args);
+  };
+
   const script = document.createElement('script');
   script.async = true;
   script.src = `https://www.googletagmanager.com/gtag/js?id=${env.PUBLIC_GOOGLE_ANALYTICS_ID}`;
   document.head.appendChild(script);
-
-  window.dataLayer = window.dataLayer || [];
-
-  window.gtag = (...args) => {
-    window.dataLayer.push(args);
-  };
 
   window.gtag('js', new Date());
   window.gtag('config', env.PUBLIC_GOOGLE_ANALYTICS_ID);


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

This PR fixes an issue where the `gtag` script was being loaded before `dataLayer` and `gtag` were declared. To resolve this, the script-loading block has been moved below the declarations to ensure that both variables are defined before the `gtag` script executes.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Set up `dataLayer` and `gtag` before loading the `gtag` script
