### PR TITLE
feat: sort learning journeys in descending order of creation

### DIFF
--- a/src/routes/(protected)/(core)/learning/collection/[id]/+page.server.ts
+++ b/src/routes/(protected)/(core)/learning/collection/[id]/+page.server.ts
@@ -69,6 +69,9 @@ export const load: PageServerLoad = async (event) => {
         collectionId: BigInt(event.params.id),
       },
     },
+    orderBy: {
+      updatedAt: 'desc',
+    },
   });
 
   return {


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->
This PR enhances the server call back to database to pull the learning journeys by descending order. This will help users to have a better view of which learning unit they are learning recently

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->
- Added `orderBy` in database query to pull data out in order of descending updating timestamp