### PR TITLE
fix: convert PostgreSQL BigInt to number for podcast count display

### DIFF
--- a/src/routes/(protected)/(core)/learning/+page.server.ts
+++ b/src/routes/(protected)/(core)/learning/+page.server.ts
@@ -43,8 +43,13 @@ export const load: PageServerLoad = async (event) => {
     GROUP BY c.id;
   `;
 
+  const collection = collections.map((collection) => ({
+    ...collection,
+    numberOfPodcasts: Number(collection.numberOfPodcasts),
+  }));
+
   return {
-    collections,
+    collections: collection,
     username: user.name,
   };
 };


### PR DESCRIPTION
Closes https://github.com/String-sg/onward/issues/349

## 🚀 Summary

This pull requests fixes the issue where the UI is showing podcasts instead of podcast when there is only 1.

<img width="802" height="333" alt="Screenshot 2025-10-17 at 4 14 42 PM" src="https://github.com/user-attachments/assets/ddc684e7-e7d8-436c-825a-97d703123d5d" />
