### PR TITLE
feat: sort collections based on last updated time on learning journey

### DIFF
--- a/src/routes/(protected)/(core)/learning/+page.server.ts
+++ b/src/routes/(protected)/(core)/learning/+page.server.ts
@@ -40,7 +40,8 @@ export const load: PageServerLoad = async (event) => {
     INNER JOIN learning_units lu ON lu.id = lj.learning_unit_id
     INNER JOIN collections c ON c.id = lu.collection_id
     WHERE lj.user_id = ${user.id}
-    GROUP BY c.id;
+    GROUP BY c.id
+    ORDER BY MAX(lj.updated_at) DESC;
   `;
 
   return {


### PR DESCRIPTION
Closes #358 

## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->
This PR is a continuation of #365, which is to order collections based on the most recent journey that the user has interacted with. This provides ease of access for users to see which collection and unit they have last interacted and able to access them easily

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->
- Modified query to order by the learning journey last updated time that will show which collection to come 1st