### PR TITLE
fix: use standard function with `arguments` when declaring `gtag` function

### DIFF
--- a/src/lib/helpers/analytics.ts
+++ b/src/lib/helpers/analytics.ts
@@ -17,8 +17,9 @@ export function initAnalytics() {
   }
 
   window.dataLayer = window.dataLayer || [];
-  window.gtag = (...args) => {
-    window.dataLayer.push(args);
+  window.gtag = function () {
+    // eslint-disable-next-line prefer-rest-params
+    window.dataLayer.push(arguments);
   };
 
   const script = document.createElement('script');


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

This PR updates the `gtag` function to use a standard function with `arguments` instead of rest parameters.  Google Analytics (GA4) requires `gtag` to be declared using a standard function so that the `arguments` object is passed correctly to the data layer. Using rest parameters (`...args`) results in an unexpected data structure that GA4 cannot interpret.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Replaced arrow function with a regular function that uses `arguments` when declaring `gtag`