### PR TITLE
feat: switch database primary keys from `bigint` to `uuidv7`

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "tsx": "^4.20.5",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.39.0",
+    "uuid": "^13.0.0",
     "vite": "^7.1.1",
     "vitest": "^3.1.4"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       typescript-eslint:
         specifier: ^8.39.0
         version: 8.39.0(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
+      uuid:
+        specifier: ^13.0.0
+        version: 13.0.0
       vite:
         specifier: ^7.1.1
         version: 7.1.1(@types/node@24.0.3)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5)(yaml@2.8.0)
@@ -2806,6 +2809,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@13.0.0:
+    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+    hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
@@ -5943,6 +5950,8 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  uuid@13.0.0: {}
 
   uuid@9.0.1: {}
 

--- a/prisma/migrations/00000000000000_create_uuidv7_function/migration.sql
+++ b/prisma/migrations/00000000000000_create_uuidv7_function/migration.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE FUNCTION uuid_generate_v7(timestamptz DEFAULT clock_timestamp()) RETURNS uuid
+AS $$
+  -- Replace the first 48 bits of a uuidv4 with the current
+  -- number of milliseconds since 1970-01-01 UTC
+  -- and set the "ver" field to 7 by setting additional bits
+  select encode(
+    set_bit(
+      set_bit(
+        overlay(uuid_send(gen_random_uuid()) placing
+	  substring(int8send((extract(epoch from $1)*1000)::bigint) from 3)
+	  from 1 for 6),
+	52, 1),
+      53, 1), 'hex')::uuid;
+$$ LANGUAGE sql volatile parallel safe;

--- a/prisma/migrations/20251018220029_use_uuidv7_as_primary_key/migration.sql
+++ b/prisma/migrations/20251018220029_use_uuidv7_as_primary_key/migration.sql
@@ -1,0 +1,234 @@
+/*
+  Warnings:
+
+  - The primary key for the `collection_tags` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `collections` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `collections` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `learning_journeys` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `learning_journeys` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `learning_unit_sources` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `learning_unit_sources` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `learning_unit_sources_tags` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `learning_unit_tags` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `learning_units` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `learning_units` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `messages` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `messages` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `question_answers` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `question_answers` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `tags` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `tags` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `threads` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `threads` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `users` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `users` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - Changed the type of `collection_id` on the `collection_tags` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `tag_id` on the `collection_tags` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `user_id` on the `learning_journeys` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `learning_unit_id` on the `learning_journeys` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `user_id` on the `learning_unit_sentiments` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `learning_unit_id` on the `learning_unit_sentiments` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `learning_unit_id` on the `learning_unit_sources` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `learning_unit_source_id` on the `learning_unit_sources_tags` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `tag_id` on the `learning_unit_sources_tags` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `learning_unit_id` on the `learning_unit_tags` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `tag_id` on the `learning_unit_tags` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `collection_id` on the `learning_units` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `thread_id` on the `messages` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `learning_unit_id` on the `question_answers` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `user_id` on the `threads` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- DropForeignKey
+ALTER TABLE "public"."collection_tags" DROP CONSTRAINT "collection_tags_collection_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."collection_tags" DROP CONSTRAINT "collection_tags_tag_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."learning_journeys" DROP CONSTRAINT "learning_journeys_learning_unit_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."learning_journeys" DROP CONSTRAINT "learning_journeys_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."learning_unit_sentiments" DROP CONSTRAINT "learning_unit_sentiments_learning_unit_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."learning_unit_sentiments" DROP CONSTRAINT "learning_unit_sentiments_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."learning_unit_sources" DROP CONSTRAINT "learning_unit_sources_learning_unit_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."learning_unit_sources_tags" DROP CONSTRAINT "learning_unit_sources_tags_learning_unit_source_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."learning_unit_sources_tags" DROP CONSTRAINT "learning_unit_sources_tags_tag_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."learning_unit_tags" DROP CONSTRAINT "learning_unit_tags_learning_unit_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."learning_unit_tags" DROP CONSTRAINT "learning_unit_tags_tag_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."learning_units" DROP CONSTRAINT "learning_units_collection_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."messages" DROP CONSTRAINT "messages_thread_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."question_answers" DROP CONSTRAINT "question_answers_learning_unit_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."threads" DROP CONSTRAINT "threads_user_id_fkey";
+
+-- AlterTable
+ALTER TABLE "public"."collection_tags" DROP CONSTRAINT "collection_tags_pkey",
+DROP COLUMN "collection_id",
+ADD COLUMN     "collection_id" UUID NOT NULL,
+DROP COLUMN "tag_id",
+ADD COLUMN     "tag_id" UUID NOT NULL,
+ADD CONSTRAINT "collection_tags_pkey" PRIMARY KEY ("collection_id", "tag_id");
+
+-- AlterTable
+ALTER TABLE "public"."collections" DROP CONSTRAINT "collections_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuid_generate_v7(),
+ADD CONSTRAINT "collections_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "public"."learning_journeys" DROP CONSTRAINT "learning_journeys_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuid_generate_v7(),
+DROP COLUMN "user_id",
+ADD COLUMN     "user_id" UUID NOT NULL,
+DROP COLUMN "learning_unit_id",
+ADD COLUMN     "learning_unit_id" UUID NOT NULL,
+ADD CONSTRAINT "learning_journeys_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "public"."learning_unit_sentiments" DROP COLUMN "user_id",
+ADD COLUMN     "user_id" UUID NOT NULL,
+DROP COLUMN "learning_unit_id",
+ADD COLUMN     "learning_unit_id" UUID NOT NULL;
+
+-- AlterTable
+ALTER TABLE "public"."learning_unit_sources" DROP CONSTRAINT "learning_unit_sources_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuid_generate_v7(),
+DROP COLUMN "learning_unit_id",
+ADD COLUMN     "learning_unit_id" UUID NOT NULL,
+ADD CONSTRAINT "learning_unit_sources_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "public"."learning_unit_sources_tags" DROP CONSTRAINT "learning_unit_sources_tags_pkey",
+DROP COLUMN "learning_unit_source_id",
+ADD COLUMN     "learning_unit_source_id" UUID NOT NULL,
+DROP COLUMN "tag_id",
+ADD COLUMN     "tag_id" UUID NOT NULL,
+ADD CONSTRAINT "learning_unit_sources_tags_pkey" PRIMARY KEY ("learning_unit_source_id", "tag_id");
+
+-- AlterTable
+ALTER TABLE "public"."learning_unit_tags" DROP CONSTRAINT "learning_unit_tags_pkey",
+DROP COLUMN "learning_unit_id",
+ADD COLUMN     "learning_unit_id" UUID NOT NULL,
+DROP COLUMN "tag_id",
+ADD COLUMN     "tag_id" UUID NOT NULL,
+ADD CONSTRAINT "learning_unit_tags_pkey" PRIMARY KEY ("learning_unit_id", "tag_id");
+
+-- AlterTable
+ALTER TABLE "public"."learning_units" DROP CONSTRAINT "learning_units_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuid_generate_v7(),
+DROP COLUMN "collection_id",
+ADD COLUMN     "collection_id" UUID NOT NULL,
+ADD CONSTRAINT "learning_units_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "public"."messages" DROP CONSTRAINT "messages_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuid_generate_v7(),
+DROP COLUMN "thread_id",
+ADD COLUMN     "thread_id" UUID NOT NULL,
+ADD CONSTRAINT "messages_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "public"."question_answers" DROP CONSTRAINT "question_answers_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuid_generate_v7(),
+DROP COLUMN "learning_unit_id",
+ADD COLUMN     "learning_unit_id" UUID NOT NULL,
+ADD CONSTRAINT "question_answers_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "public"."tags" DROP CONSTRAINT "tags_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuid_generate_v7(),
+ADD CONSTRAINT "tags_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "public"."threads" DROP CONSTRAINT "threads_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuid_generate_v7(),
+DROP COLUMN "user_id",
+ADD COLUMN     "user_id" UUID NOT NULL,
+ADD CONSTRAINT "threads_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "public"."users" DROP CONSTRAINT "users_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL DEFAULT uuid_generate_v7(),
+ADD CONSTRAINT "users_pkey" PRIMARY KEY ("id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "learning_journeys_user_id_learning_unit_id_key" ON "public"."learning_journeys"("user_id", "learning_unit_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "learning_unit_sentiments_user_id_learning_unit_id_key" ON "public"."learning_unit_sentiments"("user_id", "learning_unit_id");
+
+-- AddForeignKey
+ALTER TABLE "public"."learning_units" ADD CONSTRAINT "learning_units_collection_id_fkey" FOREIGN KEY ("collection_id") REFERENCES "public"."collections"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."learning_unit_sentiments" ADD CONSTRAINT "learning_unit_sentiments_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."learning_unit_sentiments" ADD CONSTRAINT "learning_unit_sentiments_learning_unit_id_fkey" FOREIGN KEY ("learning_unit_id") REFERENCES "public"."learning_units"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."learning_unit_sources" ADD CONSTRAINT "learning_unit_sources_learning_unit_id_fkey" FOREIGN KEY ("learning_unit_id") REFERENCES "public"."learning_units"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."learning_journeys" ADD CONSTRAINT "learning_journeys_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."learning_journeys" ADD CONSTRAINT "learning_journeys_learning_unit_id_fkey" FOREIGN KEY ("learning_unit_id") REFERENCES "public"."learning_units"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."collection_tags" ADD CONSTRAINT "collection_tags_collection_id_fkey" FOREIGN KEY ("collection_id") REFERENCES "public"."collections"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."collection_tags" ADD CONSTRAINT "collection_tags_tag_id_fkey" FOREIGN KEY ("tag_id") REFERENCES "public"."tags"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."learning_unit_tags" ADD CONSTRAINT "learning_unit_tags_learning_unit_id_fkey" FOREIGN KEY ("learning_unit_id") REFERENCES "public"."learning_units"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."learning_unit_tags" ADD CONSTRAINT "learning_unit_tags_tag_id_fkey" FOREIGN KEY ("tag_id") REFERENCES "public"."tags"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."learning_unit_sources_tags" ADD CONSTRAINT "learning_unit_sources_tags_learning_unit_source_id_fkey" FOREIGN KEY ("learning_unit_source_id") REFERENCES "public"."learning_unit_sources"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."learning_unit_sources_tags" ADD CONSTRAINT "learning_unit_sources_tags_tag_id_fkey" FOREIGN KEY ("tag_id") REFERENCES "public"."tags"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."threads" ADD CONSTRAINT "threads_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."messages" ADD CONSTRAINT "messages_thread_id_fkey" FOREIGN KEY ("thread_id") REFERENCES "public"."threads"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."question_answers" ADD CONSTRAINT "question_answers_learning_unit_id_fkey" FOREIGN KEY ("learning_unit_id") REFERENCES "public"."learning_units"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,7 +10,7 @@ datasource db {
 }
 
 model User {
-  id        BigInt   @id @default(autoincrement()) @map("id")
+  id        String   @id @default(dbgenerated("uuid_generate_v7()")) @map("id") @db.Uuid
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
   updatedAt DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(3)
 
@@ -29,7 +29,7 @@ model User {
 }
 
 model Collection {
-  id        BigInt   @id @default(autoincrement()) @map("id")
+  id        String   @id @default(dbgenerated("uuid_generate_v7()")) @map("id") @db.Uuid
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
   updatedAt DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(3)
 
@@ -57,7 +57,7 @@ enum CollectionType {
 }
 
 model LearningUnit {
-  id        BigInt   @id @default(autoincrement()) @map("id")
+  id        String   @id @default(dbgenerated("uuid_generate_v7()")) @map("id") @db.Uuid
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
   updatedAt DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(3)
 
@@ -71,7 +71,7 @@ model LearningUnit {
   isRecommended Boolean     @default(false) @map("is_recommended")
 
   // Relations.
-  collectionId BigInt @map("collection_id")
+  collectionId String @map("collection_id") @db.Uuid
 
   collection       Collection               @relation(fields: [collectionId], references: [id])
   sentiments       LearningUnitSentiments[]
@@ -91,8 +91,8 @@ model LearningUnitSentiments {
   hasLiked Boolean @map("has_liked")
 
   // Relations.
-  userId         BigInt @map("user_id")
-  learningUnitId BigInt @map("learning_unit_id")
+  userId         String @map("user_id") @db.Uuid
+  learningUnitId String @map("learning_unit_id") @db.Uuid
 
   user         User         @relation(fields: [userId], references: [id])
   learningUnit LearningUnit @relation(fields: [learningUnitId], references: [id])
@@ -102,7 +102,7 @@ model LearningUnitSentiments {
 }
 
 model LearningUnitSources {
-  id        BigInt   @id @default(autoincrement()) @map("id")
+  id        String   @id @default(dbgenerated("uuid_generate_v7()")) @map("id") @db.Uuid
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
   updatedAt DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(3)
 
@@ -111,9 +111,10 @@ model LearningUnitSources {
   sourceURL String @map("source_url")
 
   // Relations.
-  learningUnitId BigInt                   @map("learning_unit_id")
-  learningUnit   LearningUnit             @relation(fields: [learningUnitId], references: [id])
-  tags           LearningUnitSourcesTag[]
+  learningUnitId String @map("learning_unit_id") @db.Uuid
+
+  learningUnit LearningUnit             @relation(fields: [learningUnitId], references: [id])
+  tags         LearningUnitSourcesTag[]
 
   @@map("learning_unit_sources")
 }
@@ -123,7 +124,7 @@ enum ContentType {
 }
 
 model LearningJourney {
-  id        BigInt   @id @default(autoincrement()) @map("id")
+  id        String   @id @default(dbgenerated("uuid_generate_v7()")) @map("id") @db.Uuid
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
   updatedAt DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(3)
 
@@ -132,8 +133,8 @@ model LearningJourney {
   lastCheckpoint Decimal @map("last_checkpoint")
 
   // Relations.
-  userId         BigInt @map("user_id")
-  learningUnitId BigInt @map("learning_unit_id")
+  userId         String @map("user_id") @db.Uuid
+  learningUnitId String @map("learning_unit_id") @db.Uuid
 
   user         User         @relation(fields: [userId], references: [id])
   learningUnit LearningUnit @relation(fields: [learningUnitId], references: [id])
@@ -143,7 +144,7 @@ model LearningJourney {
 }
 
 model Tag {
-  id        BigInt   @id @default(autoincrement()) @map("id")
+  id        String   @id @default(dbgenerated("uuid_generate_v7()")) @map("id") @db.Uuid
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
   updatedAt DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(3)
 
@@ -161,8 +162,8 @@ model Tag {
 
 model CollectionTag {
   // Relations.
-  collectionId BigInt @map("collection_id")
-  tagId        BigInt @map("tag_id")
+  collectionId String @map("collection_id") @db.Uuid
+  tagId        String @map("tag_id") @db.Uuid
 
   collection Collection @relation(fields: [collectionId], references: [id], onDelete: Cascade)
   tag        Tag        @relation(fields: [tagId], references: [id], onDelete: Cascade)
@@ -173,8 +174,8 @@ model CollectionTag {
 
 model LearningUnitTag {
   // Relations.
-  learningUnitId BigInt @map("learning_unit_id")
-  tagId          BigInt @map("tag_id")
+  learningUnitId String @map("learning_unit_id") @db.Uuid
+  tagId          String @map("tag_id") @db.Uuid
 
   learningUnit LearningUnit @relation(fields: [learningUnitId], references: [id], onDelete: Cascade)
   tag          Tag          @relation(fields: [tagId], references: [id], onDelete: Cascade)
@@ -185,8 +186,8 @@ model LearningUnitTag {
 
 model LearningUnitSourcesTag {
   // Relations.
-  learningUnitSourceId BigInt @map("learning_unit_source_id")
-  tagId                BigInt @map("tag_id")
+  learningUnitSourceId String @map("learning_unit_source_id") @db.Uuid
+  tagId                String @map("tag_id") @db.Uuid
 
   learningUnitSource LearningUnitSources @relation(fields: [learningUnitSourceId], references: [id], onDelete: Cascade)
   tag                Tag                 @relation(fields: [tagId], references: [id], onDelete: Cascade)
@@ -196,7 +197,7 @@ model LearningUnitSourcesTag {
 }
 
 model Thread {
-  id        BigInt   @id @default(autoincrement()) @map("id")
+  id        String   @id @default(dbgenerated("uuid_generate_v7()")) @map("id") @db.Uuid
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
   updatedAt DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(3)
 
@@ -204,7 +205,7 @@ model Thread {
   isActive Boolean @default(false) @map("is_active")
 
   // Relations.
-  userId BigInt @map("user_id")
+  userId String @map("user_id") @db.Uuid
 
   user User @relation(fields: [userId], references: [id])
 
@@ -214,7 +215,7 @@ model Thread {
 }
 
 model Message {
-  id        BigInt   @id @default(autoincrement()) @map("id")
+  id        String   @id @default(dbgenerated("uuid_generate_v7()")) @map("id") @db.Uuid
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
   updatedAt DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(3)
 
@@ -223,7 +224,7 @@ model Message {
   role    Role   @map("role")
 
   // Relations.
-  threadId BigInt @map("thread_id")
+  threadId String @map("thread_id") @db.Uuid
 
   thread Thread @relation(fields: [threadId], references: [id])
 
@@ -236,7 +237,7 @@ enum Role {
 }
 
 model QuestionAnswer {
-  id        BigInt   @id @default(autoincrement()) @map("id")
+  id        String   @id @default(dbgenerated("uuid_generate_v7()")) @map("id") @db.Uuid
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
   updatedAt DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(3)
 
@@ -248,7 +249,7 @@ model QuestionAnswer {
   order       Int      @map("order") @db.SmallInt
 
   // Relations.
-  learningUnitId BigInt @map("learning_unit_id")
+  learningUnitId String @map("learning_unit_id") @db.Uuid
 
   learningUnit LearningUnit @relation(fields: [learningUnitId], references: [id])
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 
 import { PrismaPg } from '@prisma/adapter-pg';
+import { v7 as uuidv7 } from 'uuid';
 
 import {
   CollectionType,
@@ -18,22 +19,22 @@ const db = new PrismaClient({
 
 const tags: Prisma.TagCreateInput[] = [
   {
-    id: 1,
+    id: uuidv7(),
     code: 'SPECIAL_EDUCATIONAL_NEEDS',
     label: 'Special Educational Needs',
   },
   {
-    id: 2,
+    id: uuidv7(),
     code: 'LEARN_TO_USE_AI',
     label: 'Learn to Use AI',
   },
   {
-    id: 3,
+    id: uuidv7(),
     code: 'PDF',
     label: 'PDF',
   },
   {
-    id: 4,
+    id: uuidv7(),
     code: 'LINK',
     label: 'Link',
   },
@@ -41,7 +42,7 @@ const tags: Prisma.TagCreateInput[] = [
 
 const collections: Prisma.CollectionCreateInput[] = [
   {
-    id: 1,
+    id: uuidv7(),
     title: 'SEN Peer Support',
     description:
       'Explore the world of Special Educational Needs (SEN) peer support that indicates Singapore specific peer support knowledge, case studies and more to gain knowledge about SEN.',
@@ -59,7 +60,7 @@ const collections: Prisma.CollectionCreateInput[] = [
     },
   },
   {
-    id: 2,
+    id: uuidv7(),
     title: 'Learn to use AI',
     description:
       'Discover how AI is transforming education through personalized learning, intelligent tutoring systems, and data-driven insights to enhance teaching effectiveness.',
@@ -127,7 +128,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus lacinia odio vi
 
 const learningUnits: Prisma.LearningUnitCreateInput[] = [
   {
-    id: 1,
+    id: uuidv7(),
     title: 'SEN Learning Unit 1',
     contentType: ContentType.PODCAST,
     contentURL: 'http://localhost:5173',
@@ -155,7 +156,7 @@ const learningUnits: Prisma.LearningUnitCreateInput[] = [
     },
   },
   {
-    id: 2,
+    id: uuidv7(),
     title: 'SEN Learning Unit 2',
     contentType: ContentType.PODCAST,
     contentURL: 'http://localhost:5173',
@@ -183,7 +184,7 @@ const learningUnits: Prisma.LearningUnitCreateInput[] = [
     },
   },
   {
-    id: 3,
+    id: uuidv7(),
     title: 'AI Learning Unit 1',
     contentType: ContentType.PODCAST,
     contentURL: 'http://localhost:5173',
@@ -211,7 +212,7 @@ const learningUnits: Prisma.LearningUnitCreateInput[] = [
     },
   },
   {
-    id: 4,
+    id: uuidv7(),
     title: 'AI Learning Unit 2',
     contentType: ContentType.PODCAST,
     contentURL: 'http://localhost:5173',
@@ -242,7 +243,7 @@ const learningUnits: Prisma.LearningUnitCreateInput[] = [
 
 const learningUnitSources: Prisma.LearningUnitSourcesCreateInput[] = [
   {
-    id: 1,
+    id: uuidv7(),
     title: 'Learning Resource 1',
     learningUnit: {
       connect: {
@@ -263,7 +264,7 @@ const learningUnitSources: Prisma.LearningUnitSourcesCreateInput[] = [
     },
   },
   {
-    id: 2,
+    id: uuidv7(),
     title: 'Learning Resource 2',
     learningUnit: {
       connect: {
@@ -284,7 +285,7 @@ const learningUnitSources: Prisma.LearningUnitSourcesCreateInput[] = [
     },
   },
   {
-    id: 3,
+    id: uuidv7(),
     title: 'Learning Resource 3',
     learningUnit: {
       connect: {
@@ -305,7 +306,7 @@ const learningUnitSources: Prisma.LearningUnitSourcesCreateInput[] = [
     },
   },
   {
-    id: 4,
+    id: uuidv7(),
     title: 'Learning Resource 4',
     learningUnit: {
       connect: {
@@ -326,7 +327,7 @@ const learningUnitSources: Prisma.LearningUnitSourcesCreateInput[] = [
     },
   },
   {
-    id: 5,
+    id: uuidv7(),
     title: 'Learning Resource 5',
     learningUnit: {
       connect: {
@@ -347,7 +348,7 @@ const learningUnitSources: Prisma.LearningUnitSourcesCreateInput[] = [
     },
   },
   {
-    id: 6,
+    id: uuidv7(),
     title: 'Learning Resource 6',
     learningUnit: {
       connect: {
@@ -368,7 +369,7 @@ const learningUnitSources: Prisma.LearningUnitSourcesCreateInput[] = [
     },
   },
   {
-    id: 7,
+    id: uuidv7(),
     title: 'Learning Resource 7',
     learningUnit: {
       connect: {
@@ -389,7 +390,7 @@ const learningUnitSources: Prisma.LearningUnitSourcesCreateInput[] = [
     },
   },
   {
-    id: 8,
+    id: uuidv7(),
     title: 'Learning Resource 8',
     learningUnit: {
       connect: {

--- a/src/lib/helpers/analytics.ts
+++ b/src/lib/helpers/analytics.ts
@@ -34,7 +34,7 @@ export function initAnalytics() {
  * Tracks when a podcast is played.
  * @param learningUnitId - The ID of the learning unit that was played.
  */
-export function trackPodcastPlay(learningUnitId: bigint) {
+export function trackPodcastPlay(learningUnitId: string) {
   if (!browser) {
     return;
   }

--- a/src/lib/server/auth/session.ts
+++ b/src/lib/server/auth/session.ts
@@ -13,7 +13,7 @@ const DEFAULT_SESSION_ID_LENGTH = 32;
 const DEFAULT_CSRF_TOKEN_LENGTH = 32;
 
 export interface User {
-  id: string | number;
+  id: string;
   email: string;
   name: string;
 }
@@ -132,7 +132,7 @@ export default class Session {
 
     if (
       !payload['user']['id'] ||
-      (typeof payload['user']['id'] !== 'string' && typeof payload['user']['id'] !== 'number') ||
+      typeof payload['user']['id'] !== 'string' ||
       !payload['user']['email'] ||
       typeof payload['user']['email'] !== 'string' ||
       !payload['user']['name'] ||

--- a/src/lib/server/cache/avatar.ts
+++ b/src/lib/server/cache/avatar.ts
@@ -20,7 +20,7 @@ const AVATAR_TTL = 24 * 60 * 60;
  * @param userId - The ID of the user whose avatar should be retrieved.
  * @returns The base64-encoded avatar, or `null` if the user is not found.
  */
-export async function getBase64EncodedAvatar(userId: bigint): Promise<string | null> {
+export async function getBase64EncodedAvatar(userId: string): Promise<string | null> {
   let avatar = await valkey.get(`${AVATAR_NAMESPACE}:${userId}`);
   if (avatar) {
     return avatar.toString();

--- a/src/lib/states/player.svelte.ts
+++ b/src/lib/states/player.svelte.ts
@@ -7,7 +7,7 @@ const PLAYER_CONTEXT_KEY = Symbol('Player');
 const PLAYBACK_SPEED_OPTIONS = [0.5, 1.0, 1.5, 2.0];
 
 export interface Track {
-  id: number | string | bigint;
+  id: string;
   tags: { code: string; label: string }[];
   title: string;
   summary: string;

--- a/src/routes/(protected)/(core)/+layout.server.ts
+++ b/src/routes/(protected)/(core)/+layout.server.ts
@@ -14,6 +14,6 @@ export const load: LayoutServerLoad = async (event) => {
   }
 
   return {
-    avatar: await getBase64EncodedAvatar(BigInt(user.id)),
+    avatar: await getBase64EncodedAvatar(user.id),
   };
 };

--- a/src/routes/(protected)/(core)/+page.server.ts
+++ b/src/routes/(protected)/(core)/+page.server.ts
@@ -44,7 +44,7 @@ export const load: PageServerLoad = async (event) => {
       },
     },
     where: {
-      userId: BigInt(user.id),
+      userId: user.id,
       isCompleted: false,
     },
     orderBy: {
@@ -85,7 +85,7 @@ export const load: PageServerLoad = async (event) => {
       NOT: {
         learningJourneys: {
           some: {
-            userId: BigInt(user.id),
+            userId: user.id,
           },
         },
       },

--- a/src/routes/(protected)/(core)/explore/collection/[id]/+page.server.ts
+++ b/src/routes/(protected)/(core)/explore/collection/[id]/+page.server.ts
@@ -24,7 +24,7 @@ export const load: PageServerLoad = async (event) => {
       title: true,
       description: true,
     },
-    where: { id: BigInt(event.params.id) },
+    where: { id: event.params.id },
   } satisfies CollectionFindUniqueArgs;
 
   let collection: CollectionGetPayload<typeof collectionArgs> | null;
@@ -59,7 +59,7 @@ export const load: PageServerLoad = async (event) => {
       createdAt: true,
       createdBy: true,
     },
-    where: { collectionId: BigInt(event.params.id) },
+    where: { collectionId: event.params.id },
     orderBy: {
       createdAt: 'desc',
     },

--- a/src/routes/(protected)/(core)/learning/collection/[id]/+page.server.ts
+++ b/src/routes/(protected)/(core)/learning/collection/[id]/+page.server.ts
@@ -29,7 +29,7 @@ export const load: PageServerLoad = async (event) => {
   }
 
   const collection = await db.collection.findUnique({
-    where: { id: BigInt(event.params.id) },
+    where: { id: event.params.id },
     select: {
       title: true,
       description: true,
@@ -64,9 +64,9 @@ export const load: PageServerLoad = async (event) => {
       },
     },
     where: {
-      userId: BigInt(user.id),
+      userId: user.id,
       learningUnit: {
-        collectionId: BigInt(event.params.id),
+        collectionId: event.params.id,
       },
     },
     orderBy: {

--- a/src/routes/(protected)/+layout.svelte
+++ b/src/routes/(protected)/+layout.svelte
@@ -70,7 +70,7 @@
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          id: Number(player.currentTrack?.id),
+          id: player.currentTrack?.id,
           lastCheckpoint: progress,
         }),
       });

--- a/src/routes/(protected)/profile/+page.server.ts
+++ b/src/routes/(protected)/profile/+page.server.ts
@@ -23,12 +23,12 @@ export const load: PageServerLoad = async (event) => {
     const [byWeek, byMonth] = await Promise.all([
       db.learningJourney.groupBy({
         by: ['isCompleted'],
-        where: { userId: BigInt(user.id), updatedAt: { gte: startOfWeekMonday } },
+        where: { userId: user.id, updatedAt: { gte: startOfWeekMonday } },
         _count: { _all: true },
       }),
       db.learningJourney.groupBy({
         by: ['isCompleted'],
-        where: { userId: BigInt(user.id), updatedAt: { gte: firstOfMonth } },
+        where: { userId: user.id, updatedAt: { gte: firstOfMonth } },
         _count: { _all: true },
       }),
     ]);
@@ -36,7 +36,7 @@ export const load: PageServerLoad = async (event) => {
     return {
       name: user.name,
       email: user.email,
-      avatar: await getBase64EncodedAvatar(BigInt(user.id)),
+      avatar: await getBase64EncodedAvatar(user.id),
       learningUnitsConsumedByMonth: byMonth.reduce((total, group) => total + group._count._all, 0),
       learningUnitsConsumedByWeek: byWeek.reduce((total, group) => total + group._count._all, 0),
       learningUnitsCompletedByMonth: byMonth.find((group) => group.isCompleted)?._count._all ?? 0,

--- a/src/routes/(protected)/unit/[id]/+page.server.ts
+++ b/src/routes/(protected)/unit/[id]/+page.server.ts
@@ -48,7 +48,7 @@ export const load: PageServerLoad = async (event) => {
       createdAt: true,
       createdBy: true,
     },
-    where: { id: BigInt(event.params.id) },
+    where: { id: event.params.id },
   } satisfies LearningUnitFindUniqueArgs;
 
   let learningUnit: LearningUnitGetPayload<typeof learningUnitArgs> | null;
@@ -68,7 +68,7 @@ export const load: PageServerLoad = async (event) => {
     isQuizAvailable =
       (await db.questionAnswer.count({
         where: {
-          learningUnitId: BigInt(event.params.id),
+          learningUnitId: event.params.id,
         },
       })) > 0;
   } catch (err) {
@@ -82,8 +82,8 @@ export const load: PageServerLoad = async (event) => {
     },
     where: {
       userId_learningUnitId: {
-        userId: BigInt(user.id),
-        learningUnitId: BigInt(event.params.id),
+        userId: user.id,
+        learningUnitId: event.params.id,
       },
     },
   } satisfies LearningJourneyFindUniqueArgs;
@@ -102,8 +102,8 @@ export const load: PageServerLoad = async (event) => {
     },
     where: {
       userId_learningUnitId: {
-        userId: BigInt(user.id),
-        learningUnitId: BigInt(event.params.id),
+        userId: user.id,
+        learningUnitId: event.params.id,
       },
     },
   } satisfies LearningUnitSentimentsFindUniqueArgs;
@@ -118,7 +118,7 @@ export const load: PageServerLoad = async (event) => {
 
   const likesAggregateArgs = {
     where: {
-      learningUnitId: BigInt(event.params.id),
+      learningUnitId: event.params.id,
       hasLiked: true,
     },
     _count: {
@@ -150,7 +150,7 @@ export const load: PageServerLoad = async (event) => {
       },
     },
     where: {
-      learningUnitId: BigInt(event.params.id),
+      learningUnitId: event.params.id,
     },
   } satisfies LearningUnitSourcesFindManyArgs;
 
@@ -209,8 +209,8 @@ export const actions: Actions = {
       const deleteUserSentimentArgs = {
         where: {
           userId_learningUnitId: {
-            userId: BigInt(user.id),
-            learningUnitId: BigInt(event.params.id),
+            userId: user.id,
+            learningUnitId: event.params.id,
           },
         },
       } satisfies LearningUnitSentimentsDeleteArgs;
@@ -226,16 +226,16 @@ export const actions: Actions = {
       const learningUnitSentimentsArgs = {
         where: {
           userId_learningUnitId: {
-            userId: BigInt(user.id),
-            learningUnitId: BigInt(event.params.id),
+            userId: user.id,
+            learningUnitId: event.params.id,
           },
         },
         update: {
           hasLiked,
         },
         create: {
-          userId: BigInt(user.id),
-          learningUnitId: BigInt(event.params.id),
+          userId: user.id,
+          learningUnitId: event.params.id,
           hasLiked,
         },
       } satisfies LearningUnitSentimentsUpsertArgs;

--- a/src/routes/(protected)/unit/[id]/quiz/+page.server.ts
+++ b/src/routes/(protected)/unit/[id]/quiz/+page.server.ts
@@ -50,7 +50,7 @@ export const load: PageServerLoad = async (event) => {
       },
     },
     where: {
-      id: BigInt(event.params.id),
+      id: event.params.id,
     },
   } satisfies LearningUnitFindUniqueArgs;
 
@@ -104,17 +104,14 @@ export const actions: Actions = {
       return redirect(303, '/login');
     }
 
-    const userId = BigInt(user.id);
-    const learningUnitId = BigInt(event.params.id);
-
     const learningJourneyArgs = {
       where: {
-        userId_learningUnitId: { userId, learningUnitId },
+        userId_learningUnitId: { userId: user.id, learningUnitId: event.params.id },
       },
       update: { isCompleted: true },
       create: {
-        userId,
-        learningUnitId,
+        userId: user.id,
+        learningUnitId: event.params.id,
         isCompleted: true,
         lastCheckpoint: 0,
       },

--- a/src/routes/api/learningjourney/+server.ts
+++ b/src/routes/api/learningjourney/+server.ts
@@ -25,7 +25,7 @@ export const POST: RequestHandler = async (event) => {
       !params ||
       typeof params !== 'object' ||
       !('id' in params) ||
-      typeof params['id'] !== 'number' ||
+      typeof params['id'] !== 'string' ||
       !('lastCheckpoint' in params) ||
       typeof params['lastCheckpoint'] !== 'number'
     ) {
@@ -38,14 +38,14 @@ export const POST: RequestHandler = async (event) => {
 
   const learningJourneyArgs = {
     where: {
-      userId_learningUnitId: { userId: BigInt(user.id), learningUnitId: BigInt(params.id) },
+      userId_learningUnitId: { userId: user.id, learningUnitId: params.id },
     },
     update: {
       lastCheckpoint: params.lastCheckpoint,
     },
     create: {
-      userId: BigInt(user.id),
-      learningUnitId: BigInt(params.id),
+      userId: user.id,
+      learningUnitId: params.id,
       isCompleted: false,
       lastCheckpoint: params.lastCheckpoint,
     },

--- a/src/routes/api/messages/+server.ts
+++ b/src/routes/api/messages/+server.ts
@@ -19,7 +19,7 @@ export const GET: RequestHandler = async (event) => {
     const messages = await db.message.findMany({
       where: {
         thread: {
-          userId: BigInt(user.id),
+          userId: user.id,
           isActive: true,
         },
       },
@@ -78,7 +78,7 @@ export const POST: RequestHandler = async (event) => {
     select: { role: true, content: true },
     where: {
       thread: {
-        userId: BigInt(user.id),
+        userId: user.id,
         isActive: true,
       },
     },
@@ -168,13 +168,13 @@ export const POST: RequestHandler = async (event) => {
             try {
               await db.$transaction(async (tx) => {
                 let thread = await tx.thread.findFirst({
-                  where: { userId: BigInt(user.id), isActive: true },
+                  where: { userId: user.id, isActive: true },
                   select: { id: true },
                 });
 
                 if (!thread) {
                   thread = await tx.thread.create({
-                    data: { userId: BigInt(user.id), isActive: true },
+                    data: { userId: user.id, isActive: true },
                     select: { id: true },
                   });
                 }
@@ -249,7 +249,7 @@ export const DELETE: RequestHandler = async (event) => {
 
   try {
     await db.thread.updateMany({
-      where: { userId: BigInt(user.id), isActive: true },
+      where: { userId: user.id, isActive: true },
       data: { isActive: false },
     });
 


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

This PR updates the database schema to use `uuidv7` as the primary key type instead of `bigint`.  Switching to `uuidv7` ensures globally unique, time-ordered identifiers that are consistent across distributed environments.  Unlike `bigint`, `uuidv7` IDs have a fixed length, can be generated without database coordination, and remain sortable by creation time.

A custom `uuid_generate_v7()` function has also been added to the database to support environments running PostgreSQL versions below 18.  This prepares the schema for seamless migration once PostgreSQL 18 introduces native `uuidv7` support.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Added `uuid_generate_v7()` database function
- Replaced all `bigint` primary keys with `uuidv7`