### PR TITLE
feat: disable clear button when AI is responding

### DIFF
--- a/src/lib/components/ChatView/ChatView.svelte
+++ b/src/lib/components/ChatView/ChatView.svelte
@@ -292,8 +292,9 @@
 
           {#if messages.length > 0}
             <button
+              disabled={isAiTyping}
               onclick={handleClear}
-              class="cursor-pointer rounded-full p-4 font-bold transition-colors hover:bg-slate-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950 focus-visible:outline-dashed"
+              class="cursor-pointer rounded-full p-4 font-bold transition-colors hover:bg-slate-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950 focus-visible:outline-dashed disabled:pointer-events-none disabled:text-slate-900/50"
             >
               Clear
             </button>


### PR DESCRIPTION
Closes #374 

## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

This pull request disables the **Clear** button when AI is still responding.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Added `disabled` prop that depends on `isAiTyping` state.
- Added Tailwind class when button is disabled `(disabled:pointer-events-none, disabled:text-slate-900/50)`

Screenshot:
<img width="1920" height="987" alt="Screenshot 2025-10-21 at 4 20 47 AM" src="https://github.com/user-attachments/assets/6c6e5ba3-e6cd-42d2-a012-043b37836a47" />