### PR TITLE
fix: learning unit objectives width for bigger screens

### DIFF
--- a/src/routes/(protected)/unit/[id]/+page.svelte
+++ b/src/routes/(protected)/unit/[id]/+page.svelte
@@ -214,7 +214,7 @@
     </div>
   </div>
 
-  <div class={['prose prose-slate text-lg']}>
+  <div class={['prose prose-slate max-w-none text-lg']}>
     {#if browser}
       <!-- eslint-disable-next-line svelte/no-at-html-tags -->
       {@html DOMPurify.sanitize(marked.parse(data.objectives, { async: false }))}


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

This solves the issue when learning unit objectives is not using the proper width on bigger screens.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Added `max-w-none` to remove the default width from Tailwind typography.