### PR TITLE
fix: add UUID validation using `id` parameter in database query

### DIFF
--- a/src/routes/(protected)/(core)/explore/collection/[id]/+page.server.ts
+++ b/src/routes/(protected)/(core)/explore/collection/[id]/+page.server.ts
@@ -1,4 +1,5 @@
 import { error, redirect } from '@sveltejs/kit';
+import { validate as uuidValidate } from 'uuid';
 
 import {
   type CollectionFindUniqueArgs,
@@ -17,6 +18,10 @@ export const load: PageServerLoad = async (event) => {
   if (!user) {
     logger.warn('User not authenticated');
     return redirect(303, '/login');
+  }
+
+  if (!uuidValidate(event.params.id)) {
+    throw error(404);
   }
 
   const collectionArgs = {

--- a/src/routes/(protected)/(core)/learning/collection/[id]/+page.server.ts
+++ b/src/routes/(protected)/(core)/learning/collection/[id]/+page.server.ts
@@ -1,4 +1,5 @@
 import { error, redirect } from '@sveltejs/kit';
+import { validate as uuidValidate } from 'uuid';
 
 import {
   db,
@@ -26,6 +27,10 @@ export const load: PageServerLoad = async (event) => {
   if (!user) {
     logger.warn('User not authenticated');
     throw redirect(303, '/login');
+  }
+
+  if (!uuidValidate(event.params.id)) {
+    throw error(404);
   }
 
   const collection = await db.collection.findUnique({

--- a/src/routes/(protected)/unit/[id]/+page.server.ts
+++ b/src/routes/(protected)/unit/[id]/+page.server.ts
@@ -1,4 +1,5 @@
 import { error, redirect } from '@sveltejs/kit';
+import { validate as uuidValidate } from 'uuid';
 
 import auth from '$lib/server/auth';
 import {
@@ -26,6 +27,10 @@ export const load: PageServerLoad = async (event) => {
   if (!user) {
     logger.warn('User not authenticated');
     return redirect(303, '/login');
+  }
+
+  if (!uuidValidate(event.params.id)) {
+    throw error(404);
   }
 
   const learningUnitArgs = {

--- a/src/routes/(protected)/unit/[id]/quiz/+page.server.ts
+++ b/src/routes/(protected)/unit/[id]/quiz/+page.server.ts
@@ -1,4 +1,5 @@
 import { error, redirect } from '@sveltejs/kit';
+import { validate as uuidValidate } from 'uuid';
 
 import auth from '$lib/server/auth/index.js';
 import {
@@ -17,6 +18,10 @@ export const load: PageServerLoad = async (event) => {
   if (!user) {
     logger.warn('User not authenticated');
     return redirect(303, '/login');
+  }
+
+  if (!uuidValidate(event.params.id)) {
+    throw error(404);
   }
 
   const learningUnitArgs = {


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

This PR fixes an issue where invalid `id` parameter is throwing database error as the data type of `id` parameter is not a UUID type which is required for database query.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Added UUID validation before using `id` parameter in database query
