### PR TITLE
feat: add custom header to Weaviate request

### DIFF
--- a/src/lib/server/weaviate.ts
+++ b/src/lib/server/weaviate.ts
@@ -15,6 +15,7 @@ const client = await Weaviate.connectToCustom({
   grpcSecure: grpcURL.protocol === 'https:',
   authCredentials: new Weaviate.ApiKey(env.WEAVIATE_API_KEY || 'secret'),
   headers: {
+    'X-Glow-Secret': env.WEAVIATE_GLOW_SECRET || '',
     'X-OpenAI-Baseurl': env.WEAVIATE_OPENAI_BASE_URL || '',
     'X-OpenAI-Api-Key': env.WEAVIATE_OPENAI_EMBEDDING_API_KEY || '',
   },


### PR DESCRIPTION
Closes #409 

## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

AWS WAF is currently blocking requests originating from Weaviate to our LiteLLM service.
To address this, we considered two possible approaches:
1. Whitelist Weaviate’s IP addresses
2. Add a custom header for Weaviate to include in its requests

We have decided to proceed with option 2, as Weaviate does not provide a fixed or publicly available list of outbound IP addresses. Using a custom header ensures that requests from Weaviate can be reliably identified and allowed through WAF, without depending on changing IP ranges.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->
- Added custom header to Weaviate request
