### PR TITLE
feat: add CSRF protection for chatbot

### DIFF
--- a/src/lib/components/ChatView/ChatView.svelte
+++ b/src/lib/components/ChatView/ChatView.svelte
@@ -136,8 +136,9 @@
       const response = await fetch('/api/messages', {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json',
           Accept: 'text/event-stream',
+          'Content-Type': 'application/json',
+          'x-csrf-token': page.data.csrfToken,
         },
         body: JSON.stringify(bodyParams),
       });

--- a/src/routes/(protected)/+layout.server.ts
+++ b/src/routes/(protected)/+layout.server.ts
@@ -13,5 +13,6 @@ export const load: LayoutServerLoad = async (event) => {
 
   return {
     username: user.name,
+    csrfToken: event.locals.session.csrfToken(),
   };
 };


### PR DESCRIPTION
Closes #376 

## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

This solves the CSRF vulnerability for the **AI Chat**.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Added `csrfToken` in page data for building the fetch request.
- Added `x-csrf-token` header when sending the user query.
- Added CSRF validation on Chat messages POST request handler.
- Aligned the HTTP request validation properly, starting with content type validation, authentication, and CSRF protection, then payload validation.