### PR TITLE
feat: add css positioning to make img touch done button

### DIFF
--- a/src/routes/(protected)/unit/[id]/quiz/+page.svelte
+++ b/src/routes/(protected)/unit/[id]/quiz/+page.svelte
@@ -235,14 +235,14 @@
       </div>
     </div>
 
-    <div class="mt-2.5">
+    <div class="relative mt-2.5 pb-20">
       <enhanced:img
         src="$lib/assets/completion-splash.png?w=644"
         alt="Completion splash"
         class="w-[322px]"
       />
 
-      <div class="flex flex-col gap-y-5">
+      <div class="absolute inset-x-0 bottom-0 flex flex-col gap-y-5">
         <LinkButton href={`/unit/${params.id}`} variant="primary" width="full" class="max-w-sm">
           Done
         </LinkButton>


### PR DESCRIPTION
Closes https://github.com/String-sg/onward/issues/414

## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

This PR updates the quiz completion page so that the image touches the Done button instead of floating.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Add CSS positioning to the buttons.