### PR TITLE
feat: add ga events for 20 and 100 percent podcast play

### DIFF
--- a/src/lib/helpers/analytics.ts
+++ b/src/lib/helpers/analytics.ts
@@ -46,15 +46,15 @@ export function trackPodcastPlay(learningUnitId: string) {
 }
 
 /**
- * Tracks when a podcast is played at 80% completion.
+ * Tracks when a podcast is played at 20% completion.
  * @param learningUnitId - The ID of the learning unit that was played.
  */
-export function track80PercentPodcastPlay(learningUnitId: string) {
+export function track20PercentPodcastPlay(learningUnitId: string) {
   if (!browser) {
     return;
   }
 
-  window.gtag('event', 'podcast_play_80_percent', {
+  window.gtag('event', 'podcast_play_20_percent', {
     learning_unit_id: learningUnitId,
   });
 }

--- a/src/routes/(protected)/+layout.svelte
+++ b/src/routes/(protected)/+layout.svelte
@@ -9,7 +9,7 @@
   import { Modal } from '$lib/components/Modal/index.js';
   import { NowPlayingBar } from '$lib/components/NowPlayingBar/index.js';
   import { NowPlayingView } from '$lib/components/NowPlayingView/index.js';
-  import { noop, track80PercentPodcastPlay, trackPodcastCompletion } from '$lib/helpers/index.js';
+  import { noop, track20PercentPodcastPlay, trackPodcastCompletion } from '$lib/helpers/index.js';
   import { Player } from '$lib/states/index.js';
 
   const { children } = $props();
@@ -102,25 +102,33 @@
       updateLearningJourney(player.progress);
     };
 
-    const handleEightyPercentPodcast = () => {
-      track80PercentPodcastPlay(player.currentTrack!.id);
+    const handleTwentyPercentPodcast = () => {
+      if (!player.currentTrack) {
+        return;
+      }
+
+      track20PercentPodcastPlay(player.currentTrack.id);
     };
 
     const handleHundredPercentPodcast = () => {
-      trackPodcastCompletion(player.currentTrack!.id);
+      if (!player.currentTrack) {
+        return;
+      }
+
+      trackPodcastCompletion(player.currentTrack.id);
     };
 
     player.addEventListener('pause', handlePause);
     player.addEventListener('ended', handleEnded);
     player.addEventListener('checkpoint', handleCheckpoint);
-    player.addEventListener('eightyPercent', handleEightyPercentPodcast);
+    player.addEventListener('twentyPercent', handleTwentyPercentPodcast);
     player.addEventListener('hundredPercent', handleHundredPercentPodcast);
 
     return () => {
       player.removeEventListener('pause', handlePause);
       player.removeEventListener('ended', handleEnded);
       player.removeEventListener('checkpoint', handleCheckpoint);
-      player.removeEventListener('eightyPercent', handleEightyPercentPodcast);
+      player.removeEventListener('twentyPercent', handleTwentyPercentPodcast);
       player.removeEventListener('hundredPercent', handleHundredPercentPodcast);
     };
   });


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

-  This PR adds two GA events to track 20% and 100% completion of the podcast play.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Added `#hasTracked20Percent` - flag to track if 20% event already fired
- Added `#hasTracked100Percent` - flag to track if 100% event already fired

Note: There is seeking when user seeks directly to 20% or 100% without listening as progress in the player state will be updated `ontimeupdate`. The only way to prevent this is to remove seeking but it is not the ideal state for now.
