### PR TITLE
feat: update mandatory section text in learning unit page

### DIFF
--- a/src/routes/(protected)/unit/[id]/+page.svelte
+++ b/src/routes/(protected)/unit/[id]/+page.svelte
@@ -255,8 +255,8 @@
 
   <div class="flex flex-col gap-y-6">
     <div class="flex flex-col gap-y-2 rounded-lg bg-slate-100 p-2.5">
-      <MessageCircleWarningIcon></MessageCircleWarningIcon>
-      This bite is mandatory and is due on 30 <br class="sm:hidden" /> September 2025.
+      <MessageCircleWarningIcon />
+      This bite is mandatory and is due on 30 September 2025.
     </div>
     <div class={['prose prose-slate max-w-none text-lg']}>
       {#if browser}


### PR DESCRIPTION
Closes https://github.com/String-sg/onward/issues/436

## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

This PR updates the section text in learning unit page to inform users that the bite is mandatory and has a due date.
The due date is hardcoded for now and it will be updated to pull from database.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->
<img width="337" height="434" alt="Screenshot 2025-11-13 at 11 52 32 AM" src="https://github.com/user-attachments/assets/264ea445-9014-4509-b3ed-fbc3692c360f" />

