### PR TITLE
fix: Now Playing View transcript scroll behavior

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -61,6 +61,7 @@ export default ts.config(
       'simple-import-sort': simpleImportStort,
     },
     rules: {
+      curly: 'error',
       'simple-import-sort/imports': 'error',
       'simple-import-sort/exports': 'error',
     },

--- a/src/lib/components/ChatView/ChatView.svelte
+++ b/src/lib/components/ChatView/ChatView.svelte
@@ -60,7 +60,9 @@
 
   // Auto resize textarea.
   $effect(() => {
-    if (!textareaElement) return;
+    if (!textareaElement) {
+      return;
+    }
 
     textareaElement.style.height = 'auto';
     textareaElement.style.height = query ? `${Math.min(textareaElement.scrollHeight, 96)}px` : '';

--- a/src/lib/components/FileInput/FileInput.svelte
+++ b/src/lib/components/FileInput/FileInput.svelte
@@ -24,7 +24,9 @@
   let selectedFile = $state<File | null>(null);
 
   const isFileValid = (file: File): boolean => {
-    if (!accept) return true;
+    if (!accept) {
+      return true;
+    }
 
     const acceptedFileTypes = accept.split(',').map((t) => t.trim());
     const fileType = file.type;

--- a/src/lib/components/NowPlayingView/NowPlayingView.svelte
+++ b/src/lib/components/NowPlayingView/NowPlayingView.svelte
@@ -2,6 +2,7 @@
   import { ChevronDown, Pause, Play, RotateCcw, RotateCw } from '@lucide/svelte';
   import DOMPurify from 'dompurify';
   import { marked } from 'marked';
+  import type { UIEventHandler } from 'svelte/elements';
 
   import { Badge } from '$lib/components/Badge/index.js';
   import { Modal, type ModalProps } from '$lib/components/Modal/index.js';
@@ -75,12 +76,46 @@
     onspeedchange,
   }: Props = $props();
 
+  let scrollContainer = $state<HTMLDivElement>();
+  let atTop = $state(true);
+  let atBottom = $state(true);
+
+  const updateScrollState = () => {
+    if (!scrollContainer) {
+      return;
+    }
+
+    const { scrollTop, scrollHeight, clientHeight } = scrollContainer;
+    atTop = scrollTop <= 0;
+    atBottom = scrollTop + clientHeight >= scrollHeight - 1;
+  };
+
+  $effect(() => {
+    if (!scrollContainer) {
+      return;
+    }
+
+    const observer = new ResizeObserver(updateScrollState);
+    observer.observe(scrollContainer);
+    if (scrollContainer.firstElementChild) {
+      observer.observe(scrollContainer.firstElementChild);
+    }
+
+    return () => {
+      observer.disconnect();
+    };
+  });
+
   const handleClose = () => {
     onclose();
   };
 
   const handlePositionChange: SliderProps['onvaluechange'] = (value) => {
     onseek(value);
+  };
+
+  const handleScroll: UIEventHandler<HTMLDivElement> = () => {
+    updateScrollState();
   };
 </script>
 
@@ -97,7 +132,15 @@
       </button>
     </div>
 
-    <div class="overflow-y-auto mask-t-from-98% mask-b-from-90%">
+    <div
+      bind:this={scrollContainer}
+      onscroll={handleScroll}
+      class={[
+        'min-h-0 flex-1 overflow-y-auto',
+        !atTop && 'mask-t-from-98%',
+        !atBottom && 'mask-b-from-90%',
+      ]}
+    >
       <div class="prose prose-white max-w-none pb-4 text-lg">
         <!-- eslint-disable-next-line svelte/no-at-html-tags -->
         {@html DOMPurify.sanitize(marked.parse(currenttrack.summary, { async: false }))}

--- a/src/lib/components/NowPlayingView/NowPlayingView.test.ts
+++ b/src/lib/components/NowPlayingView/NowPlayingView.test.ts
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, test, vi } from 'vitest';
+import { beforeAll, describe, expect, test, vi } from 'vitest';
+
+import { noop } from '$lib/helpers/index.js';
 
 import { NowPlayingView } from './index.js';
 
@@ -11,6 +13,20 @@ vi.mock('$env/dynamic/public', () => ({
 }));
 
 describe('NowPlayingView', () => {
+  beforeAll(() => {
+    globalThis.ResizeObserver = class {
+      observe() {
+        noop();
+      }
+      unobserve() {
+        noop();
+      }
+      disconnect() {
+        noop();
+      }
+    };
+  });
+
   const defaultProps = {
     isopen: true,
     onclose: vi.fn(),

--- a/src/lib/components/Slider/Slider.svelte
+++ b/src/lib/components/Slider/Slider.svelte
@@ -48,7 +48,9 @@
 
   // Handle pointer down and movement
   const updateSlider = (clientX: number) => {
-    if (!slider) return;
+    if (!slider) {
+      return;
+    }
 
     const rect = slider.getBoundingClientRect();
     const input: [number, number] = [rect.left, rect.right];

--- a/src/lib/components/Slider/Slider.test.ts
+++ b/src/lib/components/Slider/Slider.test.ts
@@ -126,7 +126,9 @@ describe('Slider', () => {
     });
 
     const slider = container.querySelector('div');
-    if (!slider) throw new Error('Slider not found');
+    if (!slider) {
+      throw new Error('Slider not found');
+    }
 
     vi.spyOn(slider, 'getBoundingClientRect').mockReturnValue({
       left: 0,
@@ -161,7 +163,9 @@ describe('Slider', () => {
     });
 
     const slider = container.querySelector('div');
-    if (!slider) throw new Error('Slider not found');
+    if (!slider) {
+      throw new Error('Slider not found');
+    }
 
     vi.spyOn(slider, 'getBoundingClientRect').mockReturnValue({
       left: 0,

--- a/src/lib/server/unit/validation.test.ts
+++ b/src/lib/server/unit/validation.test.ts
@@ -6,7 +6,9 @@ function makeFormData(fields: Record<string, string | string[]>): FormData {
   const fd = new FormData();
   for (const [key, val] of Object.entries(fields)) {
     if (Array.isArray(val)) {
-      for (const v of val) fd.append(key, v);
+      for (const v of val) {
+        fd.append(key, v);
+      }
     } else {
       fd.set(key, val);
     }

--- a/src/lib/server/unit/validation.ts
+++ b/src/lib/server/unit/validation.ts
@@ -72,7 +72,9 @@ function parseContentItems(
       }
     }
 
-    if (Object.keys(err).length > 0) itemErrors[i] = err;
+    if (Object.keys(err).length > 0) {
+      itemErrors[i] = err;
+    }
   }
 
   if (itemErrors.some((e) => Object.keys(e).length > 0)) {


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->

This PR fixes:

- The scroll behavior for the transcript of the podcast UI on mobile screens.
- The masking/fading effect issue when at the end of the transcript.
- The convention for one liner guard functions.

## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->

- Updated eslint config.
- Added scroll observer for the fading effect.
- Added guard for transcript/summary container scrollable area on mobile screens.