### PR TITLE
feat: update Quiz Incorrect answer UI

### DIFF
--- a/src/routes/(main)/(protected)/unit/[id]/quiz/+page.svelte
+++ b/src/routes/(main)/(protected)/unit/[id]/quiz/+page.svelte
@@ -173,7 +173,7 @@
 <Modal isopen={isFeedbackModalOpen} onclose={toggleFeedbackModalVisibility} size="partial">
   <header class="sticky inset-x-0 top-0 bg-white/90 backdrop-blur-sm">
     <div class="mx-auto flex max-w-5xl items-center justify-between px-4 py-3">
-      <span class="text-xl font-medium">
+      <span class={['text-xl font-medium', !isCorrectAnswer && 'text-red-600']}>
         {isCorrectAnswer ? 'Correct answer!' : 'Not quite right!'}
       </span>
 
@@ -194,19 +194,19 @@
         <div
           class={[
             'flex items-center gap-x-3 rounded-2xl border px-2.5 py-3.5',
-            isCorrectAnswer ? 'border-transparent bg-lime-200' : 'border-slate-950 bg-white',
+            isCorrectAnswer ? 'border-transparent bg-lime-200' : 'border-red-600 bg-white',
           ]}
         >
           <span
             class={[
               'flex h-8 w-8 shrink-0 items-center justify-center rounded-lg font-semibold',
-              isCorrectAnswer ? 'bg-lime-400' : 'bg-slate-950 text-white',
+              isCorrectAnswer ? 'bg-lime-400' : 'bg-red-500 text-white',
             ]}
           >
             {String.fromCharCode(65 + selectedOptionIndex)}
           </span>
 
-          <span class="text-left">
+          <span class={['text-left', !isCorrectAnswer && 'text-red-600']}>
             {currentQuestionAnswer.options[selectedOptionIndex]}
           </span>
         </div>


### PR DESCRIPTION
## 🚀 Summary

<!--
Provide a clear and concise description of the changes you're making.
What problem does this solve? What is the motivation behind this change?
-->          

  This PR updates the quiz feedback modal's incorrect-answer state to use red as the visual cue, replacing the previous neutral slate styling. The new color scheme makes wrong 
  answers more immediately recognizable and aligns better with conventional UX patterns (red = error/incorrect), mirroring the lime palette already used for correct answers.
                                                                                                                                                                                
## ✏️ Changes

<!--
List the specific changes you've made. For example:
- Added new feature X
- Fixed bug in Y
- Updated documentation for Z
-->  

  - Applied text-red-600 to the "Not quite right!" heading when the answer is incorrect                                                                                         
  - Changed the selected-answer card border from border-slate-950 to border-red-600 for incorrect answers
  - Changed the option letter square background from bg-slate-950 to bg-red-500 for incorrect answers                                                                           
  - Applied text-red-600 to the selected option text when the answer is incorrect
