### PR TITLE
feat: update Player buttons UI

### DIFF
--- a/src/routes/(main)/(protected)/unit/[id]/+page.svelte
+++ b/src/routes/(main)/(protected)/unit/[id]/+page.svelte
@@ -7,11 +7,11 @@
     Headphones,
     Lightbulb,
     MessageCircleWarningIcon,
+    MonitorPlay,
     Pause,
     ThumbsDown,
     ThumbsUp,
     TriangleAlert,
-    Video,
     X,
   } from '@lucide/svelte';
   import { formatDistanceToNow } from 'date-fns';
@@ -65,6 +65,7 @@
 
   const podcastContent = $derived(data.contents.find((c) => c.type === 'PODCAST'));
   const videoContent = $derived(data.contents.find((c) => c.type === 'VIDEO'));
+  const hasPodcastAndVideo = $derived(Boolean(podcastContent && videoContent));
 
   let podcastCheckpoint = $derived(podcastContent ? (data.checkpoints[podcastContent.id] ?? 0) : 0);
   let videoCheckpoint = $derived(videoContent ? (data.checkpoints[videoContent.id] ?? 0) : 0);
@@ -343,32 +344,52 @@
       <div class="flex flex-col gap-y-4">
         {#if podcastContent}
           {#if isActive && player.isPlaying}
-            <Button variant="primary" width="full" onclick={handlePause}>
+            <Button
+              variant={hasPodcastAndVideo ? 'secondary' : 'primary'}
+              width="full"
+              onclick={handlePause}
+            >
               <Pause class="h-4 w-4" />
               <span class="font-medium">Pause</span>
             </Button>
           {:else if isActive && !player.isPlaying}
-            <Button variant="primary" width="full" onclick={handleResume}>
+            <Button
+              variant={hasPodcastAndVideo ? 'secondary' : 'primary'}
+              width="full"
+              onclick={handleResume}
+            >
               <Headphones class="h-4 w-4" />
-              <span class="font-medium">Listen</span>
+              <span class="font-medium">Podcast</span>
             </Button>
           {:else if podcastCheckpoint > 0}
-            <Button variant="primary" width="full" onclick={handleResume}>
+            <Button
+              variant={hasPodcastAndVideo ? 'secondary' : 'primary'}
+              width="full"
+              onclick={handleResume}
+            >
               <Headphones class="h-4 w-4" />
-              <span class="font-medium">Listen</span>
+              <span class="font-medium">Podcast</span>
             </Button>
           {:else}
-            <Button variant="primary" width="full" onclick={handlePlay}>
+            <Button
+              variant={hasPodcastAndVideo ? 'secondary' : 'primary'}
+              width="full"
+              onclick={handlePlay}
+            >
               <Headphones class="h-4 w-4" />
-              <span class="font-medium">Listen</span>
+              <span class="font-medium">Podcast</span>
             </Button>
           {/if}
         {/if}
 
         {#if videoContent}
-          <Button variant="secondary" width="full" onclick={handleWatch}>
-            <Video class="h-4 w-4" />
-            <span class="font-medium">Watch</span>
+          <Button
+            variant={hasPodcastAndVideo ? 'secondary' : 'primary'}
+            width="full"
+            onclick={handleWatch}
+          >
+            <MonitorPlay class="h-4 w-4" />
+            <span class="font-medium">Video</span>
           </Button>
         {/if}
 


### PR DESCRIPTION
## 🚀 Summary

Updates the Learning Unit page's content-action buttons to better reflect what they trigger and to balance their visual weight. Renames the buttons to match their underlying content types ("Podcast"/"Video" instead of the verb-based "Listen"/"Watch"), swaps the Video button's icon to the more recognisable monitor-with-play, and adjusts variant hierarchy so neither action visually dominates when both content types are available on a unit.

## ✏️ Changes

- Renamed the **"Listen" button → "Podcast"** across all three podcast play states (initial play, resume, resume-from-checkpoint). The "Pause" label is intentionally unchanged.
- Renamed the **"Watch" button → "Video"**.
- Replaced the lucide `Video` icon on the Video button with **`MonitorPlay`** (monitor outline with a play triangle).
- Added a `hasPodcastAndVideo` derived state on `+page.svelte`. When both content types are present on a unit, both buttons render as `secondary` so neither dominates; when only one type is present, that single CTA renders as `primary`.
- File touched: `src/routes/(main)/(protected)/unit/[id]/+page.svelte` (only).

<img width="1919" height="1004" alt="Screenshot 2026-04-29 at 3 37 13 PM" src="https://github.com/user-attachments/assets/5669ccdc-fc3d-417f-8121-dda91f3a5ed0" />
