### PR TITLE
feat: add help link to login page

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -88,6 +88,11 @@ const tags: Prisma.TagCreateInput[] = [
     code: 'LINK',
     label: 'Link',
   },
+  {
+    id: uuidv7(),
+    code: 'INTRA',
+    label: 'Intranet',
+  },
 ];
 
 const collections: Prisma.CollectionCreateInput[] = [

--- a/src/lib/helpers/mapping.ts
+++ b/src/lib/helpers/mapping.ts
@@ -16,6 +16,7 @@ const BADGE_TYPE_INFO: Record<string, { variant: BadgeProps['variant']; label: s
   EMP_ENGAGEMENT: { variant: 'blue', label: 'Employee engagement' },
   PDF: { variant: 'slate', label: 'PDF' },
   LINK: { variant: 'slate', label: 'Link' },
+  INTRA: { variant: 'slate', label: 'Intranet' },
   REQUIRED: { variant: 'slate-light', label: 'Required' },
   OVERDUE: { variant: 'slate-light', label: 'Overdue' },
   COMPLETED: { variant: 'slate-light', label: 'Completed' },

--- a/src/routes/(main)/(protected)/unit/[id]/+page.svelte
+++ b/src/routes/(main)/(protected)/unit/[id]/+page.svelte
@@ -473,10 +473,12 @@
           class="inline-flex gap-x-4 rounded-2xl border border-slate-200 bg-white p-3"
         >
           <div class="flex w-[calc(100%-36px)] flex-col gap-y-1">
-            {#each source.tags.map((t) => t.tag) as tag (tag)}
-              {@const badgeInfo = getBadgeInfo(tag.code)}
-              <Badge variant={badgeInfo.variant}>{badgeInfo.label}</Badge>
-            {/each}
+            <div class="flex flex-wrap gap-2">
+              {#each source.tags.map((t) => t.tag) as tag (tag)}
+                {@const badgeInfo = getBadgeInfo(tag.code)}
+                <Badge variant={badgeInfo.variant}>{badgeInfo.label}</Badge>
+              {/each}
+            </div>
 
             <span class="truncate">
               {source.title}

--- a/src/routes/(main)/login/+page.svelte
+++ b/src/routes/(main)/login/+page.svelte
@@ -45,6 +45,15 @@
                 </a>.
               </span>
             </span>
+
+            <a
+              href="https://ask.gov.sg/glow"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-center text-xs underline"
+            >
+              Have questions?
+            </a>
           </div>
         </div>
 


### PR DESCRIPTION
## 🚀 Summary

Adds a help link on login, a new Intranet tag, and tidies source tag layout.

## ✏️ Changes

- Added "Have questions?" link to login page
- Added Intranet tag
- Display source tags in a single row

<img width="1919" height="1004" alt="Screenshot 2026-05-04 at 4 50 17 PM" src="https://github.com/user-attachments/assets/c8d59c6f-8698-42bd-9d31-67acc0f59e9d" />

<img width="1919" height="1004" alt="Screenshot 2026-05-05 at 10 56 23 AM" src="https://github.com/user-attachments/assets/22f408a5-c65e-463b-aa25-854c6f39afdc" />