### PR TITLE
release: v1.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.13.2 (2026-05-11)
+
+### Bug Fixes 🐛
+
+- fix: podcast delivery to CDN ([#561](https://github.com/String-sg/onward/pull/561)) ([f09b804d](https://github.com/String-sg/onward/commit/f09b804d))
+
 ## 1.13.1 (2026-05-08)
 
 ### Bug Fixes 🐛

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onward",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## 1.13.2 (2026-05-11)

### Bug Fixes 🐛

- fix: podcast delivery to CDN ([#561](https://github.com/String-sg/onward/pull/561)) ([f09b804d](https://github.com/String-sg/onward/commit/f09b804d))