### PR TITLE
chore: pin pnpm to 10.33.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -46,8 +44,6 @@ jobs:
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -70,8 +66,6 @@ jobs:
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -98,8 +92,6 @@ jobs:
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
+        with:
+          version: ~11.1.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -44,6 +46,8 @@ jobs:
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
+        with:
+          version: ~11.1.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -66,6 +70,8 @@ jobs:
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
+        with:
+          version: ~11.1.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -92,6 +98,8 @@ jobs:
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
+        with:
+          version: ~11.1.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
         with:
-          version: ~11.1.0
+          version: 10.33.4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -47,7 +47,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
         with:
-          version: ~11.1.0
+          version: 10.33.4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -71,7 +71,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
         with:
-          version: ~11.1.0
+          version: 10.33.4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -99,7 +99,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
         with:
-          version: ~11.1.0
+          version: 10.33.4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,13 +77,7 @@ To contribute code, you'll need to set up your development environment.
 **Prerequisites:**
 
 - **Node.js:** Version 24. You can use a version manager like [fnm](https://github.com/Schniz/fnm) or [nvm](https://github.com/nvm-sh/nvm) to manage Node.js versions.
-- **pnpm:** We use `pnpm` for package management, pinned via the `packageManager` field in `package.json`. Enable [Corepack](https://nodejs.org/api/corepack.html) (shipped with Node.js) so the pinned version is used automatically:
-
-  ```sh
-  corepack enable
-  ```
-
-  Alternatively, install pnpm manually via Homebrew (`brew install pnpm`) or the official [pnpm installation guide](https://pnpm.io/installation), but note that your local version may drift from the pinned one.
+- **pnpm:** We use `pnpm` for package management, pinned via the `packageManager` field in `package.json`. Install pnpm via Homebrew (`brew install pnpm`) or the official [pnpm installation guide](https://pnpm.io/installation); pnpm will automatically use the pinned version when run inside this repo.
 
 **Steps:**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,13 @@ To contribute code, you'll need to set up your development environment.
 **Prerequisites:**
 
 - **Node.js:** Version 24. You can use a version manager like [fnm](https://github.com/Schniz/fnm) or [nvm](https://github.com/nvm-sh/nvm) to manage Node.js versions.
-- **pnpm:** We use `pnpm` for package management. Install it using Homebrew: `brew install pnpm`, or follow the official [pnpm installation guide](https://pnpm.io/installation) for other systems.
+- **pnpm:** We use `pnpm` for package management, pinned via the `packageManager` field in `package.json`. Enable [Corepack](https://nodejs.org/api/corepack.html) (shipped with Node.js) so the pinned version is used automatically:
+
+  ```sh
+  corepack enable
+  ```
+
+  Alternatively, install pnpm manually via Homebrew (`brew install pnpm`) or the official [pnpm installation guide](https://pnpm.io/installation), but note that your local version may drift from the pinned one.
 
 **Steps:**
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ ENV NODE_ENV="production"
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN mkdir $PNPM_HOME && \
-        wget -qO- "https://github.com/pnpm/pnpm/releases/download/v11.1.1/pnpm-linux-arm64-musl.tar.gz" \
-        | tar -xz -C $PNPM_HOME && \
+        wget -qO- "https://github.com/pnpm/pnpm/releases/download/v10.33.4/pnpm-linuxstatic-arm64" > "$PNPM_HOME/pnpm" && \
+        chmod +x $PNPM_HOME/pnpm && \
         ln -s $PNPM_HOME/pnpm /usr/local/bin/pnpm
 
 # ----------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV NODE_ENV="production"
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN mkdir $PNPM_HOME && \
-        wget -qO- "https://github.com/pnpm/pnpm/releases/download/v10.18.1/pnpm-linuxstatic-arm64" > "$PNPM_HOME/pnpm" && \
+        wget -qO- "https://github.com/pnpm/pnpm/releases/download/v11.1.1/pnpm-linuxstatic-arm64" > "$PNPM_HOME/pnpm" && \
         chmod +x $PNPM_HOME/pnpm && \
         ln -s $PNPM_HOME/pnpm /usr/local/bin/pnpm
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ ENV NODE_ENV="production"
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN mkdir $PNPM_HOME && \
-        wget -qO- "https://github.com/pnpm/pnpm/releases/download/v11.1.1/pnpm-linuxstatic-arm64" > "$PNPM_HOME/pnpm" && \
-        chmod +x $PNPM_HOME/pnpm && \
+        wget -qO- "https://github.com/pnpm/pnpm/releases/download/v11.1.1/pnpm-linux-arm64-musl.tar.gz" \
+        | tar -xz -C $PNPM_HOME && \
         ln -s $PNPM_HOME/pnpm /usr/local/bin/pnpm
 
 # ----------------------------------------

--- a/package.json
+++ b/package.json
@@ -3,13 +3,7 @@
   "version": "1.14.1",
   "private": true,
   "type": "module",
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "version": "~11.1.0",
-      "onFail": "download"
-    }
-  },
+  "packageManager": "pnpm@10.33.4",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,13 @@
   "version": "1.14.1",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@11.1.1+sha512.d1fdf5f73c617b64fa1a56a81c3c8dfe0e966e33a6010aa256b517ae77be21d93e05affc0de1a83b0e4f29d569f68b446ae8f068cd7247c0bb3df0fb4d7bdf9a",
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "11.1.1",
+      "onFail": "download"
+    }
+  },
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.14.1",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@11.1.1+sha512.d1fdf5f73c617b64fa1a56a81c3c8dfe0e966e33a6010aa256b517ae77be21d93e05affc0de1a83b0e4f29d569f68b446ae8f068cd7247c0bb3df0fb4d7bdf9a",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": "11.1.1",
+      "version": "~11.1.0",
       "onFail": "download"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,97 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: ~10.0.0
+        version: 10.0.0
+      pnpm:
+        specifier: ~10.0.0
+        version: 10.0.0
+
+packages:
+
+  '@pnpm/exe@10.0.0':
+    resolution: {integrity: sha512-FlbDw+DK5v40lVSn2AdOOnacdAur9aHa1Y3EcpMahTQyn3jwYZAK9+/E3r040SGBfTfXyr13Dew93LbuFJm9vw==}
+    hasBin: true
+
+  '@pnpm/linux-arm64@10.0.0':
+    resolution: {integrity: sha512-DST7XuIcsUAkZcx/tqapPguWHtf+gzAEGzsH4MnYbzKLjKpG46IQMlfot+WYFwX6a4zSJbd1turWMFHn0nSqnQ==}
+    cpu: [arm64]
+    os: [linux]
+    hasBin: true
+
+  '@pnpm/linux-x64@10.0.0':
+    resolution: {integrity: sha512-O23iO2OGkOXsBbONTgDYFLQSIfKze0871JDoEXPjKjwaVj/QwuCqR+HFwTrNkPr73/6eeEJ8Csxl2urhioA5tg==}
+    cpu: [x64]
+    os: [linux]
+    hasBin: true
+
+  '@pnpm/macos-arm64@10.0.0':
+    resolution: {integrity: sha512-4YxQ0AHNrjD6M17cuyNgMgTRhzqwBx2tDg/yAPRnF9KjaAI6l3d3m3oNkYFzmnLgg8h6I7wU+tkSrn2JW3/zFQ==}
+    cpu: [arm64]
+    os: [darwin]
+    hasBin: true
+
+  '@pnpm/macos-x64@10.0.0':
+    resolution: {integrity: sha512-sqAHoD4vj1t+YMjhF0el8DHDqvR8rdlUfcrG5KFGULaXoddO/ZLlAC9ad/agkO2aoteSvlpx76jJt4J4Ko8Ntg==}
+    cpu: [x64]
+    os: [darwin]
+    hasBin: true
+
+  '@pnpm/win-arm64@10.0.0':
+    resolution: {integrity: sha512-NGMK7TWgwYAxmt0Jmw5wxCgS2lgNlsHqb3xmVIhyT2vbh4eog24Wgl1GpudY6ISfY0sPwBOiMQP2z+uA+v7UDA==}
+    cpu: [arm64]
+    os: [win32]
+    hasBin: true
+
+  '@pnpm/win-x64@10.0.0':
+    resolution: {integrity: sha512-OTQ4aV7K1FiRkL/izwwpHPvLm8/iihg55td+bFp2dUH2KvtCg81kHrO1wz0crgj07ONkm8Pill+csQ1c7Z+M4w==}
+    cpu: [x64]
+    os: [win32]
+    hasBin: true
+
+  pnpm@10.0.0:
+    resolution: {integrity: sha512-uP71SUvT/ky9Ttq9B0XfLuW+PksLiwj6ZDqj5MZwLMwPANaPqKjJhYpzWgAySFpEmQ7SgQUmyHXkFvABsX3xKw==}
+    engines: {node: '>=18.12'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe@10.0.0':
+    optionalDependencies:
+      '@pnpm/linux-arm64': 10.0.0
+      '@pnpm/linux-x64': 10.0.0
+      '@pnpm/macos-arm64': 10.0.0
+      '@pnpm/macos-x64': 10.0.0
+      '@pnpm/win-arm64': 10.0.0
+      '@pnpm/win-x64': 10.0.0
+
+  '@pnpm/linux-arm64@10.0.0':
+    optional: true
+
+  '@pnpm/linux-x64@10.0.0':
+    optional: true
+
+  '@pnpm/macos-arm64@10.0.0':
+    optional: true
+
+  '@pnpm/macos-x64@10.0.0':
+    optional: true
+
+  '@pnpm/win-arm64@10.0.0':
+    optional: true
+
+  '@pnpm/win-x64@10.0.0':
+    optional: true
+
+  pnpm@10.0.0: {}
+
+---
 lockfileVersion: '9.0'
 
 settings:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,202 +1,3 @@
----
-lockfileVersion: '9.0'
-
-importers:
-
-  .:
-    configDependencies: {}
-    packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: 11.1.1
-        version: 11.1.1
-      pnpm:
-        specifier: 11.1.1
-        version: 11.1.1
-
-packages:
-
-  '@pnpm/exe@11.1.1':
-    resolution: {integrity: sha512-5mQnDW1NCBRRWA+cnGhQO+tIrfSfWm3/IyGxU88LnT+tzNW5UrwwKfjsnnYJToyAjIfdfEJtJKUxCvP+mhA+nQ==}
-    hasBin: true
-
-  '@pnpm/linux-arm64@11.1.1':
-    resolution: {integrity: sha512-u9hs51XV0/gU5LLfNLoQsozGKIxNjxsh/0xPr+8Hny0M38psa4lBtwFvarL2bLToPIrtueQYi65LdlzRxITRyg==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@pnpm/linux-x64@11.1.1':
-    resolution: {integrity: sha512-yQO9i57oyJmIG22BjV7sqLUT2syKQohiku8yNZRgp7M6wsVkikpVLLVSpBifQnrI/P/roueKnWSUEESH1aPaoA==}
-    cpu: [x64]
-    os: [linux]
-
-  '@pnpm/linuxstatic-arm64@11.1.1':
-    resolution: {integrity: sha512-FUZB8L9Z8L5m88G0RTx5AsHFr5yUQPW+28zQdTNUWxiLwj11FW/fOLodYdcNYHdNJFepsZyqt3aRnpiqIdZb2g==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@pnpm/linuxstatic-x64@11.1.1':
-    resolution: {integrity: sha512-I/z56hfa1zM5F/Unup/1NrgsA+dcptsKQ2TjJLFz3wHKDx0RLrfF7DB0Rkpnr5IoAZ33v0GFZjlGhkOtc9VFGw==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@pnpm/macos-arm64@11.1.1':
-    resolution: {integrity: sha512-YQu6fC27F4jTIpXhF+4PdzOV7uSnVVG9KUxj5W+AFj0XFlUvBw+I1NsoPCY6uV1nccxWpIAZOTZtSj8+hWPb8w==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@pnpm/win-arm64@11.1.1':
-    resolution: {integrity: sha512-2HvZut3IcKPxzIfOjBJ4677PaLIh57mWccL86O+q71QhO5emnQvht0CE19IoEyUIOEe1WjlN+Su/dD5k6CuGyg==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@pnpm/win-x64@11.1.1':
-    resolution: {integrity: sha512-QXBIBErgPhGLovOVzTRIpHsejFKebyqlcF3fea/TfH87gkhN5yWH0WuTPRBoOWvpk6aNhjDW4RPUMx8RaPqxjw==}
-    cpu: [x64]
-    os: [win32]
-
-  '@reflink/reflink-darwin-arm64@0.1.19':
-    resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@reflink/reflink-darwin-x64@0.1.19':
-    resolution: {integrity: sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@reflink/reflink-linux-arm64-gnu@0.1.19':
-    resolution: {integrity: sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@reflink/reflink-linux-arm64-musl@0.1.19':
-    resolution: {integrity: sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@reflink/reflink-linux-x64-gnu@0.1.19':
-    resolution: {integrity: sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@reflink/reflink-linux-x64-musl@0.1.19':
-    resolution: {integrity: sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@reflink/reflink-win32-arm64-msvc@0.1.19':
-    resolution: {integrity: sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@reflink/reflink-win32-x64-msvc@0.1.19':
-    resolution: {integrity: sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@reflink/reflink@0.1.19':
-    resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
-    engines: {node: '>= 10'}
-
-  detect-libc@2.1.2:
-    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
-    engines: {node: '>=8'}
-
-  pnpm@11.1.1:
-    resolution: {integrity: sha512-0f319zxhe2T6GlaoHDyN/g6WbjOmAQqiVrUXrne+Idk+Ba/8DeGoOw5PKdVp9otEaujwaM1yR8C7PfD7TXvfmg==}
-    engines: {node: '>=22.13'}
-    hasBin: true
-
-snapshots:
-
-  '@pnpm/exe@11.1.1':
-    dependencies:
-      '@reflink/reflink': 0.1.19
-      detect-libc: 2.1.2
-    optionalDependencies:
-      '@pnpm/linux-arm64': 11.1.1
-      '@pnpm/linux-x64': 11.1.1
-      '@pnpm/linuxstatic-arm64': 11.1.1
-      '@pnpm/linuxstatic-x64': 11.1.1
-      '@pnpm/macos-arm64': 11.1.1
-      '@pnpm/win-arm64': 11.1.1
-      '@pnpm/win-x64': 11.1.1
-
-  '@pnpm/linux-arm64@11.1.1':
-    optional: true
-
-  '@pnpm/linux-x64@11.1.1':
-    optional: true
-
-  '@pnpm/linuxstatic-arm64@11.1.1':
-    optional: true
-
-  '@pnpm/linuxstatic-x64@11.1.1':
-    optional: true
-
-  '@pnpm/macos-arm64@11.1.1':
-    optional: true
-
-  '@pnpm/win-arm64@11.1.1':
-    optional: true
-
-  '@pnpm/win-x64@11.1.1':
-    optional: true
-
-  '@reflink/reflink-darwin-arm64@0.1.19':
-    optional: true
-
-  '@reflink/reflink-darwin-x64@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-arm64-gnu@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-arm64-musl@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-x64-gnu@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-x64-musl@0.1.19':
-    optional: true
-
-  '@reflink/reflink-win32-arm64-msvc@0.1.19':
-    optional: true
-
-  '@reflink/reflink-win32-x64-msvc@0.1.19':
-    optional: true
-
-  '@reflink/reflink@0.1.19':
-    optionalDependencies:
-      '@reflink/reflink-darwin-arm64': 0.1.19
-      '@reflink/reflink-darwin-x64': 0.1.19
-      '@reflink/reflink-linux-arm64-gnu': 0.1.19
-      '@reflink/reflink-linux-arm64-musl': 0.1.19
-      '@reflink/reflink-linux-x64-gnu': 0.1.19
-      '@reflink/reflink-linux-x64-musl': 0.1.19
-      '@reflink/reflink-win32-arm64-msvc': 0.1.19
-      '@reflink/reflink-win32-x64-msvc': 0.1.19
-
-  detect-libc@2.1.2: {}
-
-  pnpm@11.1.1: {}
-
----
 lockfileVersion: '9.0'
 
 settings:
@@ -218,7 +19,9 @@ overrides:
   exceljs>uuid: ^11.1.1
 
 patchedDependencies:
-  vite-imagetools: 40ee8f08a912b0823d1a8e3080e47e0baab3895ae9ed8e7bcf5e099680d18084
+  vite-imagetools:
+    hash: 40ee8f08a912b0823d1a8e3080e47e0baab3895ae9ed8e7bcf5e099680d18084
+    path: patches/vite-imagetools.patch
 
 importers:
 
@@ -1031,8 +834,8 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  '@hono/node-server@1.19.11':
-    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+  '@hono/node-server@1.19.13':
+    resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4.12.21
@@ -2433,11 +2236,11 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+  brace-expansion@1.1.13:
+    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+  brace-expansion@2.0.3:
+    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -3046,8 +2849,8 @@ packages:
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
-  hono@4.12.24:
-    resolution: {integrity: sha512-I36D1s+HgQc55KbhEr4iybfxv/9o1zdpw+XEM6dJa91LqQD0HCoSGdxpRJCZE+aavs87j4V3Ls2OJzq8C/U4iw==}
+  hono@4.12.23:
+    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@4.0.0:
@@ -5346,9 +5149,9 @@ snapshots:
       protobufjs: 7.6.2
       yargs: 17.7.2
 
-  '@hono/node-server@1.19.13(hono@4.12.24)':
+  '@hono/node-server@1.19.13(hono@4.12.23)':
     dependencies:
-      hono: 4.12.24
+      hono: 4.12.23
 
   '@humanfs/core@0.19.1': {}
 
@@ -5462,7 +5265,7 @@ snapshots:
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.4
+      '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/remapping@2.3.5':
@@ -5484,7 +5287,7 @@ snapshots:
   '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.4
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
@@ -5537,13 +5340,13 @@ snapshots:
       '@electric-sql/pglite': 0.4.1
       '@electric-sql/pglite-socket': 0.1.1(@electric-sql/pglite@0.4.1)
       '@electric-sql/pglite-tools': 0.3.1(@electric-sql/pglite@0.4.1)
-      '@hono/node-server': 1.19.13(hono@4.12.24)
+      '@hono/node-server': 1.19.13(hono@4.12.23)
       '@prisma/get-platform': 7.2.0
       '@prisma/query-plan-executor': 7.2.0
       '@prisma/streams-local': 0.1.2
       foreground-child: 3.3.1
       get-port-please: 3.2.0
-      hono: 4.12.24
+      hono: 4.12.23
       http-status-codes: 2.3.0
       pathe: 2.0.3
       proper-lockfile: 4.1.2
@@ -6734,12 +6537,12 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@1.1.15:
+  brace-expansion@1.1.13:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.1:
+  brace-expansion@2.0.3:
     dependencies:
       balanced-match: 1.0.2
 
@@ -7398,7 +7201,7 @@ snapshots:
 
   help-me@5.0.0: {}
 
-  hono@4.12.24: {}
+  hono@4.12.23: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:
@@ -7794,15 +7597,15 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.15
+      brace-expansion: 1.1.13
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 2.0.3
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 2.0.3
 
   minimist@1.2.8: {}
 
@@ -8708,6 +8511,7 @@ snapshots:
       vite-node: 3.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.5)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/debug': 4.1.12
       '@types/node': 24.10.1
       jsdom: 27.3.0(postcss@8.5.15)
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,89 +7,194 @@ importers:
     configDependencies: {}
     packageManagerDependencies:
       '@pnpm/exe':
-        specifier: ~10.0.0
-        version: 10.0.0
+        specifier: 11.1.1
+        version: 11.1.1
       pnpm:
-        specifier: ~10.0.0
-        version: 10.0.0
+        specifier: 11.1.1
+        version: 11.1.1
 
 packages:
 
-  '@pnpm/exe@10.0.0':
-    resolution: {integrity: sha512-FlbDw+DK5v40lVSn2AdOOnacdAur9aHa1Y3EcpMahTQyn3jwYZAK9+/E3r040SGBfTfXyr13Dew93LbuFJm9vw==}
+  '@pnpm/exe@11.1.1':
+    resolution: {integrity: sha512-5mQnDW1NCBRRWA+cnGhQO+tIrfSfWm3/IyGxU88LnT+tzNW5UrwwKfjsnnYJToyAjIfdfEJtJKUxCvP+mhA+nQ==}
     hasBin: true
 
-  '@pnpm/linux-arm64@10.0.0':
-    resolution: {integrity: sha512-DST7XuIcsUAkZcx/tqapPguWHtf+gzAEGzsH4MnYbzKLjKpG46IQMlfot+WYFwX6a4zSJbd1turWMFHn0nSqnQ==}
+  '@pnpm/linux-arm64@11.1.1':
+    resolution: {integrity: sha512-u9hs51XV0/gU5LLfNLoQsozGKIxNjxsh/0xPr+8Hny0M38psa4lBtwFvarL2bLToPIrtueQYi65LdlzRxITRyg==}
     cpu: [arm64]
     os: [linux]
-    hasBin: true
 
-  '@pnpm/linux-x64@10.0.0':
-    resolution: {integrity: sha512-O23iO2OGkOXsBbONTgDYFLQSIfKze0871JDoEXPjKjwaVj/QwuCqR+HFwTrNkPr73/6eeEJ8Csxl2urhioA5tg==}
+  '@pnpm/linux-x64@11.1.1':
+    resolution: {integrity: sha512-yQO9i57oyJmIG22BjV7sqLUT2syKQohiku8yNZRgp7M6wsVkikpVLLVSpBifQnrI/P/roueKnWSUEESH1aPaoA==}
     cpu: [x64]
     os: [linux]
-    hasBin: true
 
-  '@pnpm/macos-arm64@10.0.0':
-    resolution: {integrity: sha512-4YxQ0AHNrjD6M17cuyNgMgTRhzqwBx2tDg/yAPRnF9KjaAI6l3d3m3oNkYFzmnLgg8h6I7wU+tkSrn2JW3/zFQ==}
+  '@pnpm/linuxstatic-arm64@11.1.1':
+    resolution: {integrity: sha512-FUZB8L9Z8L5m88G0RTx5AsHFr5yUQPW+28zQdTNUWxiLwj11FW/fOLodYdcNYHdNJFepsZyqt3aRnpiqIdZb2g==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/linuxstatic-x64@11.1.1':
+    resolution: {integrity: sha512-I/z56hfa1zM5F/Unup/1NrgsA+dcptsKQ2TjJLFz3wHKDx0RLrfF7DB0Rkpnr5IoAZ33v0GFZjlGhkOtc9VFGw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/macos-arm64@11.1.1':
+    resolution: {integrity: sha512-YQu6fC27F4jTIpXhF+4PdzOV7uSnVVG9KUxj5W+AFj0XFlUvBw+I1NsoPCY6uV1nccxWpIAZOTZtSj8+hWPb8w==}
     cpu: [arm64]
     os: [darwin]
-    hasBin: true
 
-  '@pnpm/macos-x64@10.0.0':
-    resolution: {integrity: sha512-sqAHoD4vj1t+YMjhF0el8DHDqvR8rdlUfcrG5KFGULaXoddO/ZLlAC9ad/agkO2aoteSvlpx76jJt4J4Ko8Ntg==}
-    cpu: [x64]
-    os: [darwin]
-    hasBin: true
-
-  '@pnpm/win-arm64@10.0.0':
-    resolution: {integrity: sha512-NGMK7TWgwYAxmt0Jmw5wxCgS2lgNlsHqb3xmVIhyT2vbh4eog24Wgl1GpudY6ISfY0sPwBOiMQP2z+uA+v7UDA==}
+  '@pnpm/win-arm64@11.1.1':
+    resolution: {integrity: sha512-2HvZut3IcKPxzIfOjBJ4677PaLIh57mWccL86O+q71QhO5emnQvht0CE19IoEyUIOEe1WjlN+Su/dD5k6CuGyg==}
     cpu: [arm64]
     os: [win32]
-    hasBin: true
 
-  '@pnpm/win-x64@10.0.0':
-    resolution: {integrity: sha512-OTQ4aV7K1FiRkL/izwwpHPvLm8/iihg55td+bFp2dUH2KvtCg81kHrO1wz0crgj07ONkm8Pill+csQ1c7Z+M4w==}
+  '@pnpm/win-x64@11.1.1':
+    resolution: {integrity: sha512-QXBIBErgPhGLovOVzTRIpHsejFKebyqlcF3fea/TfH87gkhN5yWH0WuTPRBoOWvpk6aNhjDW4RPUMx8RaPqxjw==}
     cpu: [x64]
     os: [win32]
-    hasBin: true
 
-  pnpm@10.0.0:
-    resolution: {integrity: sha512-uP71SUvT/ky9Ttq9B0XfLuW+PksLiwj6ZDqj5MZwLMwPANaPqKjJhYpzWgAySFpEmQ7SgQUmyHXkFvABsX3xKw==}
-    engines: {node: '>=18.12'}
+  '@reflink/reflink-darwin-arm64@0.1.19':
+    resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@reflink/reflink-darwin-x64@0.1.19':
+    resolution: {integrity: sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@reflink/reflink-linux-arm64-gnu@0.1.19':
+    resolution: {integrity: sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@reflink/reflink-linux-arm64-musl@0.1.19':
+    resolution: {integrity: sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@reflink/reflink-linux-x64-gnu@0.1.19':
+    resolution: {integrity: sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@reflink/reflink-linux-x64-musl@0.1.19':
+    resolution: {integrity: sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@reflink/reflink-win32-arm64-msvc@0.1.19':
+    resolution: {integrity: sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@reflink/reflink-win32-x64-msvc@0.1.19':
+    resolution: {integrity: sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@reflink/reflink@0.1.19':
+    resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
+    engines: {node: '>= 10'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  pnpm@11.1.1:
+    resolution: {integrity: sha512-0f319zxhe2T6GlaoHDyN/g6WbjOmAQqiVrUXrne+Idk+Ba/8DeGoOw5PKdVp9otEaujwaM1yR8C7PfD7TXvfmg==}
+    engines: {node: '>=22.13'}
     hasBin: true
 
 snapshots:
 
-  '@pnpm/exe@10.0.0':
+  '@pnpm/exe@11.1.1':
+    dependencies:
+      '@reflink/reflink': 0.1.19
+      detect-libc: 2.1.2
     optionalDependencies:
-      '@pnpm/linux-arm64': 10.0.0
-      '@pnpm/linux-x64': 10.0.0
-      '@pnpm/macos-arm64': 10.0.0
-      '@pnpm/macos-x64': 10.0.0
-      '@pnpm/win-arm64': 10.0.0
-      '@pnpm/win-x64': 10.0.0
+      '@pnpm/linux-arm64': 11.1.1
+      '@pnpm/linux-x64': 11.1.1
+      '@pnpm/linuxstatic-arm64': 11.1.1
+      '@pnpm/linuxstatic-x64': 11.1.1
+      '@pnpm/macos-arm64': 11.1.1
+      '@pnpm/win-arm64': 11.1.1
+      '@pnpm/win-x64': 11.1.1
 
-  '@pnpm/linux-arm64@10.0.0':
+  '@pnpm/linux-arm64@11.1.1':
     optional: true
 
-  '@pnpm/linux-x64@10.0.0':
+  '@pnpm/linux-x64@11.1.1':
     optional: true
 
-  '@pnpm/macos-arm64@10.0.0':
+  '@pnpm/linuxstatic-arm64@11.1.1':
     optional: true
 
-  '@pnpm/macos-x64@10.0.0':
+  '@pnpm/linuxstatic-x64@11.1.1':
     optional: true
 
-  '@pnpm/win-arm64@10.0.0':
+  '@pnpm/macos-arm64@11.1.1':
     optional: true
 
-  '@pnpm/win-x64@10.0.0':
+  '@pnpm/win-arm64@11.1.1':
     optional: true
 
-  pnpm@10.0.0: {}
+  '@pnpm/win-x64@11.1.1':
+    optional: true
+
+  '@reflink/reflink-darwin-arm64@0.1.19':
+    optional: true
+
+  '@reflink/reflink-darwin-x64@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-arm64-gnu@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-arm64-musl@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-x64-gnu@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-x64-musl@0.1.19':
+    optional: true
+
+  '@reflink/reflink-win32-arm64-msvc@0.1.19':
+    optional: true
+
+  '@reflink/reflink-win32-x64-msvc@0.1.19':
+    optional: true
+
+  '@reflink/reflink@0.1.19':
+    optionalDependencies:
+      '@reflink/reflink-darwin-arm64': 0.1.19
+      '@reflink/reflink-darwin-x64': 0.1.19
+      '@reflink/reflink-linux-arm64-gnu': 0.1.19
+      '@reflink/reflink-linux-arm64-musl': 0.1.19
+      '@reflink/reflink-linux-x64-gnu': 0.1.19
+      '@reflink/reflink-linux-x64-musl': 0.1.19
+      '@reflink/reflink-win32-arm64-msvc': 0.1.19
+      '@reflink/reflink-win32-x64-msvc': 0.1.19
+
+  detect-libc@2.1.2: {}
+
+  pnpm@11.1.1: {}
 
 ---
 lockfileVersion: '9.0'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,9 +19,7 @@ overrides:
   exceljs>uuid: ^11.1.1
 
 patchedDependencies:
-  vite-imagetools:
-    hash: 40ee8f08a912b0823d1a8e3080e47e0baab3895ae9ed8e7bcf5e099680d18084
-    path: patches/vite-imagetools.patch
+  vite-imagetools: 40ee8f08a912b0823d1a8e3080e47e0baab3895ae9ed8e7bcf5e099680d18084
 
 importers:
 
@@ -834,8 +832,8 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  '@hono/node-server@1.19.13':
-    resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
+  '@hono/node-server@1.19.11':
+    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4.12.21
@@ -8511,7 +8509,6 @@ snapshots:
       vite-node: 3.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.5)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/debug': 4.1.12
       '@types/node': 24.10.1
       jsdom: 27.3.0(postcss@8.5.15)
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,13 +1,13 @@
 minimumReleaseAge: 10080
 
-onlyBuiltDependencies:
-  - '@prisma/client'
-  - '@prisma/engines'
-  - '@tailwindcss/oxide'
-  - esbuild
-  - prisma
-  - protobufjs
-  - sharp
+allowBuilds:
+  '@prisma/client': true
+  '@prisma/engines': true
+  '@tailwindcss/oxide': true
+  esbuild: true
+  prisma: true
+  protobufjs: true
+  sharp: true
 
 patchedDependencies:
   vite-imagetools: patches/vite-imagetools.patch


### PR DESCRIPTION
## 🚀 Summary

This PR pins pnpm to `10.33.4` via the `packageManager` field.

## ✏️ Changes

- Pinned pnpm to `10.33.4` in `package.json` via `packageManager` field
- Pinned pnpm to `10.33.4` in CI workflow
- Migrated `onlyBuiltDependencies` to `allowBuilds` in `pnpm-workspace.yaml`
- Updated `Dockerfile` to install pnpm `10.33.4`
- Updated `CONTRIBUTING.md` with pnpm install instructions