### PR TITLE
docs: add ADRs for report exports

### DIFF
--- a/docs/decisions/0001-stream-report-exports-with-exceljs.md
+++ b/docs/decisions/0001-stream-report-exports-with-exceljs.md
@@ -1,0 +1,69 @@
+---
+status: 'accepted'
+date: 2026-06-08
+decision-makers: santosral
+consulted:
+informed:
+---
+
+# Stream report exports end-to-end with ExcelJS via a generic helper
+
+## Context and Problem Statement
+
+The admin quiz export (`admin/api/download`) loads every matching row into memory, builds the whole workbook, and serializes it to a single buffer before sending, so memory scales linearly with row count. As data grows a single export can spike memory and destabilize the server. We also have a second report (onboarding) coming that would otherwise copy the same buffered pattern. How should report exports be produced so memory stays bounded and the logic is reusable?
+
+## Decision Drivers
+
+- Bounded memory regardless of dataset size — neither the full result set nor the full file should be held in memory.
+- Reusable across reports so additional exports plug in without re-implementing streaming.
+- Keep Prisma's typed query API.
+- Avoid duplicating the error-prone streaming loop per endpoint.
+
+## Considered Options
+
+- Stream end-to-end with `ExcelJS.stream.xlsx.WorkbookWriter` piped to the HTTP response, encapsulated in a single generic streaming helper
+- Buffer-then-send (the current approach) — build the whole workbook in memory, send one buffer
+- Thin streaming utilities only — expose helpers but let each endpoint own its streaming loop
+- A config/registry-driven export framework that endpoints register against
+
+## Decision Outcome
+
+Chosen option: "Stream end-to-end with ExcelJS via a generic streaming helper", because it is the only option that bounds memory on both the DB read and the file write while keeping each endpoint tiny and declarative.
+
+The helper writes through a Node `stream.PassThrough`, whose readable side is converted with `Readable.toWeb()` and returned as the SvelteKit `Response` body. The write loop runs un-awaited so the response starts streaming immediately; because it is not awaited it carries its own `.catch`. Once streaming starts the status and headers are already sent, so a mid-export error cannot become a clean 500 — the helper hands the failure back to the caller through an injected error callback (which logs server-side) and destroys the stream, leaving the browser with a failed/incomplete download to retry. Keeping the helper logger-agnostic and free of any SvelteKit request object decouples it from the framework and makes it trivially unit-testable. (Cursor batching of the DB read is a separate decision — see [ADR-0002](./0002-keyset-cursor-pagination-on-primary-key.md).)
+
+### Consequences
+
+- Good, because memory is bounded regardless of dataset size, removing the DoS vector.
+- Good, because one tested helper owns all the streaming complexity and endpoints only declare their columns, a batch-fetch closure, and an error callback.
+- Good, because migrating the quiz export off the vendored `xlsx` tarball lets us remove that dependency entirely.
+- Bad, because a mid-stream error after headers are sent cannot be a clean error response — the admin sees a broken download and retries.
+- Bad, because the un-awaited write loop must carry its own `.catch` or a failure surfaces as an unhandled rejection.
+- Bad, because it adds `exceljs` as a dependency.
+
+### Confirmation
+
+The quiz endpoint is rewritten to call the streaming helper and the vendored `xlsx` dependency is removed; tests assert the helper drives the batch fetcher to exhaustion, produces a readable stream, and aborts + reports the failure on a fetch error.
+
+## Pros and Cons of the Options
+
+### Stream end-to-end via a generic streaming helper
+
+- Good, because it bounds memory on both read and write.
+- Good, because the streaming loop is written and tested once.
+- Bad, because the abstraction must be generic enough for every report (a columns + batch-fetch contract).
+
+### Buffer-then-send (current approach)
+
+- Good, because errors can still become a clean 500 (nothing is sent yet).
+- Bad, because memory scales with row count — the problem we are removing.
+
+### Thin streaming utilities only
+
+- Good, because no large abstraction to design.
+- Bad, because every endpoint re-implements the error-prone streaming/abort loop.
+
+### Config/registry-driven framework
+
+- Good, because exports become pure data.
+- Bad, because it is over-engineering for the current two reports (YAGNI).

--- a/docs/decisions/0002-keyset-cursor-pagination-on-primary-key.md
+++ b/docs/decisions/0002-keyset-cursor-pagination-on-primary-key.md
@@ -1,0 +1,61 @@
+---
+status: 'accepted'
+date: 2026-06-08
+decision-makers: santosral
+consulted:
+informed:
+---
+
+# Read streaming exports with keyset cursor pagination on the primary key
+
+## Context and Problem Statement
+
+The streaming export ([ADR-0001](./0001-stream-report-exports-with-exceljs.md)) reads rows from the database in batches inside a loop that runs until the data is exhausted. How should each batch be fetched so the per-batch cost stays constant at any depth and rows are neither skipped nor duplicated under concurrent writes?
+
+## Decision Drivers
+
+- Constant per-batch cost regardless of how deep into the result set the loop has read.
+- Stability under concurrent writes — no skipped or duplicated rows.
+- Keep Prisma's typed query API.
+
+## Considered Options
+
+- Keyset (cursor) pagination ordered by the model's primary key
+- Offset pagination (`skip` / `take`)
+- A true DB server-side cursor via the raw `pg` driver (`pg-query-stream`)
+
+## Decision Outcome
+
+Chosen option: "Keyset pagination ordered by the primary key", because it is linear and index-backed (constant cost per batch) and stable under concurrent writes, while staying within Prisma's typed cursor API.
+
+A consequence is that the export is **no longer ordered by `user.name`** (today's behavior). Name lives on the related `User` and is non-unique, so it cannot back a clean keyset cursor; since an admin can sort any column in Excel, server-side name ordering is dropped in favor of primary-key ordering.
+
+### Consequences
+
+- Good, because batch cost is constant and index-backed at any depth.
+- Good, because the read is stable under concurrent inserts/deletes (no skip/duplicate).
+- Good, because it stays within Prisma's typed API.
+- Bad, because the exported rows are ordered by primary key rather than `user.name`; mitigated because the admin can sort the downloaded file in Excel.
+- Neutral, because a true server-side cursor (`pg-query-stream`) would remove repeated queries entirely but bypasses Prisma's typed API — deferred as an escalation path if scale ever demands it.
+
+### Confirmation
+
+Endpoint tests assert the cursor advances across multiple batches and the `where` filter is honored; the `fetchBatch` contract returns `{ rows, nextCursor }` and the loop terminates when `nextCursor` is undefined.
+
+## Pros and Cons of the Options
+
+### Keyset cursor on the primary key
+
+- Good, because cost per batch is constant and index-backed.
+- Good, because it is stable under concurrent writes.
+- Bad, because ordering is tied to the key, not a human-friendly column.
+
+### Offset pagination (`skip` / `take`)
+
+- Good, because it can order by any column, including `user.name`.
+- Bad, because cost grows with depth and rows can be skipped or duplicated when the underlying set changes mid-export.
+
+### Raw `pg` server-side cursor (`pg-query-stream`)
+
+- Good, because it removes repeated queries entirely.
+- Bad, because it bypasses Prisma's typed API — too much for current scale (deferred).

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,40 @@
+# Architecture Decision Records
+
+This directory holds Architecture Decision Records (ADRs) following the
+[MADR 4.0](https://adr.github.io/madr/) standard. Each ADR captures one
+architectural decision: the problem, the options considered, the chosen option,
+and its consequences (good _and_ bad).
+
+## Relationship to specs
+
+Design specs live in [`../superpowers/specs/`](../superpowers/specs/). A spec
+records only the **chosen** solution and links out to the relevant ADR here for
+the full rationale and the alternatives that were rejected. The decision lives in
+the ADR; the spec consumes its outcome.
+
+> Rule of thumb: if you're writing "we considered X but chose Y because…", that
+> belongs in an ADR, not the spec. The spec just states Y and links the ADR.
+
+## Conventions
+
+- **One decision per file**, named `NNNN-kebab-title.md` (zero-padded, e.g.
+  `0001-stream-report-exports-with-exceljs.md`). Numbers are sequential and never
+  reused.
+- **Start from the template:** copy [`TEMPLATE.md`](./TEMPLATE.md) (the
+  official MADR 4.0 full template). Keep its optional sections — including Pros
+  and Cons of the Options — so every decision records its alternatives and
+  rationale.
+- **Frontmatter** carries `status`, `date`, `decision-makers`, `consulted`,
+  `informed`. For a solo/small-team change, `status` + `date` is enough; leave
+  the rest blank.
+- **Status lifecycle:** `proposed` → `accepted` → (later) `deprecated` or
+  `superseded by ADR-NNNN`. A `rejected` option is recorded too if it was
+  seriously considered.
+- **Immutable once accepted:** don't rewrite an accepted ADR. If the decision
+  changes, write a new ADR that supersedes it and update the old one's status.
+
+## Index
+
+- [0001 — Stream report exports end-to-end with ExcelJS via a generic helper](./0001-stream-report-exports-with-exceljs.md) — accepted
+- [0002 — Read streaming exports with keyset cursor pagination on the primary key](./0002-keyset-cursor-pagination-on-primary-key.md) — accepted
+- [0003 — Nested per-report download routes and inline query-param tabs](./0003-report-export-routing-and-tabs.md) — accepted

--- a/docs/decisions/TEMPLATE.md
+++ b/docs/decisions/TEMPLATE.md
@@ -1,0 +1,85 @@
+---
+# These are optional metadata elements. Feel free to remove any of them.
+status: '{proposed | rejected | accepted | deprecated | … | superseded by ADR-0123}'
+date: { YYYY-MM-DD when the decision was last updated }
+decision-makers: { list everyone involved in the decision }
+consulted:
+  {
+    list everyone whose opinions are sought (typically subject-matter experts); and with whom there is a two-way communication,
+  }
+informed:
+  {
+    list everyone who is kept up-to-date on progress; and with whom there is a one-way communication,
+  }
+---
+
+# {short title, representative of solved problem and found solution}
+
+## Context and Problem Statement
+
+{Describe the context and problem statement, e.g., in free form using two to three sentences or in the form of an illustrative story. You may want to articulate the problem in form of a question and add links to collaboration boards or issue management systems.}
+
+<!-- This is an optional element. Feel free to remove. -->
+
+## Decision Drivers
+
+- {decision driver 1, e.g., a force, facing concern, …}
+- {decision driver 2, e.g., a force, facing concern, …}
+- … <!-- numbers of drivers can vary -->
+
+## Considered Options
+
+- {title of option 1}
+- {title of option 2}
+- {title of option 3}
+- … <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: "{title of option 1}", because {justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force {force} | … | comes out best (see below)}.
+
+<!-- This is an optional element. Feel free to remove. -->
+
+### Consequences
+
+- Good, because {positive consequence, e.g., improvement of one or more desired qualities, …}
+- Bad, because {negative consequence, e.g., compromising one or more desired qualities, …}
+- … <!-- numbers of consequences can vary -->
+
+<!-- This is an optional element. Feel free to remove. -->
+
+### Confirmation
+
+{Describe how the implementation of/compliance with the ADR can/will be confirmed. Are the design that was decided for and its implementation in line with the decision made? E.g., a design/code review or a test with a library such as ArchUnit can help validate this. Note that although we classify this element as optional, it is included in many ADRs.}
+
+<!-- This is an optional element. Feel free to remove. -->
+
+## Pros and Cons of the Options
+
+### {title of option 1}
+
+<!-- This is an optional element. Feel free to remove. -->
+
+{example | description | pointer to more information | …}
+
+- Good, because {argument a}
+- Good, because {argument b}
+- Neutral, because {argument c}
+- Bad, because {argument d}
+- … <!-- numbers of pros and cons can vary -->
+
+### {title of other option}
+
+{example | description | pointer to more information | …}
+
+- Good, because {argument a}
+- Good, because {argument b}
+- Neutral, because {argument c}
+- Bad, because {argument d}
+- …
+
+<!-- This is an optional element. Feel free to remove. -->
+
+## More Information
+
+{You might want to provide additional evidence/confidence for the decision outcome here and/or document the team agreement on the decision and/or define when/how this decision the decision should be realized and if/when it should be re-visited. Links to other decisions and resources might appear here as well.}


### PR DESCRIPTION
## 🚀 Summary

This PR adds the architecture decision records behind the streaming report export work.

## ✏️ Changes

- Add ADR-0001: stream report exports end-to-end with ExcelJS via a generic helper
- Add ADR-0002: keyset cursor pagination on the primary key
- Add the `docs/decisions/` README and MADR 4.0 template

Part of #571.
