### PR TITLE
docs: add streaming report exports spec

### DIFF
--- a/docs/superpowers/specs/2026-06-08-streaming-report-exports-design.md
+++ b/docs/superpowers/specs/2026-06-08-streaming-report-exports-design.md
@@ -1,0 +1,139 @@
+# Streaming Report Exports (ExcelJS) — Design
+
+**Status:** Draft
+**Issue:** none
+**Depends on / Related:** foundation for [Onboarding Report](./2026-06-08-onboarding-report-design.md) (Spec B). This is Spec A; Spec B builds on the helper defined here.
+
+## Overview
+
+The admin quiz export (`admin/api/download`) loads every matching row into memory, builds the whole workbook, and serializes it to a single buffer before sending, so memory scales linearly with row count. As data grows, a single export can spike memory and destabilize the server. There is also no reusable export path, so the upcoming onboarding report would otherwise copy the same buffered pattern. This spec replaces that with a memory-bounded, end-to-end streaming export built on ExcelJS: rows are read from the database in cursor-batched pages straight into an ExcelJS `WorkbookWriter`, whose output is piped to the HTTP response, so neither the full result set nor the full file is ever held in memory. The streaming logic lives in one reusable helper, fixing the memory model once ahead of the onboarding report (Spec B) adding a second export.
+
+Scope: the **existing quiz export only**. The onboarding report (Spec B) reuses the helper introduced here; no UI/pagination changes to the reports page and no change to the report's columns or filename format (output is equivalent to today, minus row ordering — see Architecture).
+
+The deploy adapter is `@sveltejs/adapter-node` on Node 24, so streaming `Response` bodies (via `Readable.toWeb`) are supported. `xlsx` (SheetJS) is currently imported in exactly one place — `src/routes/admin/api/download/+server.ts` — and vendored as a local tarball (`file:vendor/xlsx-0.20.3.tgz`), so migrating the quiz export removes that dependency entirely; `exceljs` is not yet a dependency and is added by this work.
+
+## Goals
+
+- **Goal:** bounded memory regardless of dataset size — true streaming of both the DB read and the file write.
+- **Goal:** a reusable export helper so additional reports plug in without re-implementing streaming.
+
+## Architecture
+
+> Decision: stream end-to-end with ExcelJS through a generic `generateReport` helper. See [ADR-0001](../../decisions/0001-stream-report-exports-with-exceljs.md).
+> Decision: read each batch with keyset cursor pagination on the primary key. See [ADR-0002](../../decisions/0002-keyset-cursor-pagination-on-primary-key.md).
+
+`ExcelJS.stream.xlsx.WorkbookWriter` writes to a Node `stream.PassThrough`. The readable side is converted with `Readable.toWeb(passThrough)` and returned as the SvelteKit `Response` body. The write loop runs **un-awaited** so the response starts streaming immediately while rows are still being fetched and written; because it is not awaited, the loop carries its own `.catch` (see Error handling). Each iteration pulls one cursor-batched page (ordered by primary key — quiz: `LearningJourney.id`) via `fetchBatch`, writes its rows, and continues until `nextCursor` is undefined, then commits the worksheet and workbook.
+
+Because the export is ordered by primary key rather than `user.name` (today's behavior), the on-disk row order differs from before; the admin can sort any column in Excel. Per-cell sanitization (`sanitizeSpreadsheetCell`) is applied to every string cell as it is written.
+
+```mermaid
+flowchart LR
+  DB[(Postgres)] --> Fetch[fetchBatch cursor]
+  subgraph loop [write loop — un-awaited]
+    Fetch -->|rows| Write[write rows to sheet]
+    Write --> More{nextCursor?}
+    More -->|yes| Fetch
+    More -->|no| Commit[commit sheet + workbook]
+  end
+  Write --> Writer[ExcelJS WorkbookWriter]
+  Commit --> Writer
+  Writer --> PT[PassThrough]
+  PT -->|Readable.toWeb| Resp[HTTP Response body]
+```
+
+## Contracts & boundaries
+
+### `generateReport`
+
+- **Does:** turns a column definition + a cursor-driven batch fetcher into a downloadable `.xlsx` HTTP response. Delivery is streamed end-to-end (a guarantee below), but the name stays intent-level — callers never depend on the mechanism.
+- **Use:** declaration-level signature below; the caller passes columns, a `fetchBatch` closure over its Prisma query, and an optional `onError` callback.
+- **Depends on:** `exceljs` and the caller-supplied `fetchBatch`; `onError` is optional. It takes no `RequestEvent` and has no logging dependency — error observation is inverted to the caller via `onError`, so the helper stays fully decoupled from SvelteKit, from any logger, and from app/business logic. A caller that does not care to observe failures simply omits `onError`.
+- **Guarantees:** bounded memory (streams read + write); sets response headers including `Cache-Control: no-store`; sanitizes every string cell; commits the workbook when the cursor is exhausted; on a mid-stream error, **always destroys the stream** (the client sees a broken/incomplete download), and invokes `onError` if one was provided.
+- **Requires:** `fetchBatch` returns `{ rows, nextCursor }` and yields `nextCursor: undefined` exactly when the data is exhausted. `onError` is optional; when omitted, a mid-stream failure still destroys the stream but is not surfaced to the caller (unobserved by design — observation is the caller's choice, never the helper's). The helper never throws on a fetch failure, so omitting `onError` cannot produce an unhandled rejection.
+
+```ts
+interface Column<Row> {
+  header: string;
+  value: (row: Row) => string | number | boolean;
+}
+
+interface GenerateReportOptions<Row, Cursor> {
+  filename: string;
+  sheetName: string;
+  columns: Column<Row>[];
+  fetchBatch: (cursor: Cursor | undefined) => Promise<{ rows: Row[]; nextCursor: Cursor | undefined }>;
+  onError?: (err: unknown) => void;
+}
+
+generateReport<Row, Cursor>(options: GenerateReportOptions<Row, Cursor>): Response;
+```
+
+### `sanitizeSpreadsheetCell`
+
+- **Does:** neutralizes CSV/formula injection in a single string cell.
+- **Use:** `sanitizeSpreadsheetCell(value: string): string`.
+- **Depends on:** nothing.
+- **Guarantees:** prefixes a leading `=`, `+`, `-`, `@`, tab, or CR with `'`; leaves safe values unchanged.
+- **Requires:** a string input.
+
+### `formatTimestamp`
+
+- **Does:** formats a `Date` as a `DDMMYYYYHHmmss` string for report filename prefixes.
+- **Use:** `formatTimestamp(date: Date): string`.
+- **Depends on:** nothing.
+- **Guarantees:** returns 14 digits — day, month, year, hours, minutes, seconds, each zero-padded, in local time. Carries no business meaning and no filename suffix; each caller assembles its own filename around the prefix.
+- **Requires:** a `Date`.
+
+Shared by both exports (this report and the onboarding report, Spec B); co-located with `sanitizeSpreadsheetCell` in `reports/helpers.ts`. The per-report filename suffix (e.g. `_user_report.xlsx`) stays in each endpoint.
+
+Information-hiding test: an endpoint declares only its columns, `fetchBatch`, and (optionally) `onError`; the streaming loop, PassThrough bridge, headers, commit, and stream-destroy-on-error are all internal to the helper and can change without touching consumers. The helper always owns the recovery (destroying the stream); it notifies the caller through `onError` only when one is provided, so logging stays out of the helper.
+
+## Components / changes
+
+### 1. Add `exceljs`, remove vendored `xlsx`
+
+Add `exceljs` to dependencies; remove the `xlsx` entry and the `vendor/xlsx-0.20.3.tgz` tarball once the quiz endpoint no longer imports it.
+
+### 2. `src/lib/server/reports/` (new)
+
+A new feature folder following the repo's `src/lib/server/{auth,chat,unit,cache}` convention — responsibility-named source files, a barrel `index.ts` that re-exports them (`export * from './x.js'`), co-located `*.test.ts`, and consumers importing the folder (`$lib/server/reports`). It holds:
+
+- `generateReport.ts` — the generic streaming helper.
+- `helpers.ts` — the shared pure `sanitizeSpreadsheetCell` and `formatTimestamp` utilities defined under Contracts & boundaries (both referenced by Spec B).
+- `index.ts` — barrel re-exporting both.
+
+### 3. `src/routes/admin/api/download/quiz/+server.ts` (moved + modified)
+
+Moved from `admin/api/download/+server.ts` (sole `xlsx` consumer). Rewritten to use `generateReport`. **Business logic / scope is preserved**: the download still returns all rows for the selected quiz (same `where` filter, same columns, same filename), independent of the table's UI pagination. The only behavioral deltas are internal (streaming), row order (name → primary key), and the security hardening below.
+
+- Auth check (401 if no `user`) — defense-in-depth atop the `/admin` hook guard.
+- Not-found check: when a `quizId` is supplied but the lookup returns no quiz, respond 404 before streaming — a bad id is an error, not an empty report.
+- `columns`: Name, Email, Quiz Title, Is Completed (`Yes`/`No`), Number of Attempts — same as today.
+- `fetchBatch`: Prisma cursor on `LearningJourney.id`, preserving the existing `where` (`questionAnswers: { some: {} }`, optional `quizId`), selecting `user { name, email }`, `learningUnit { title }`, `isCompleted`, `numberOfAttempts`.
+- `onError`: logs the failure through the endpoint's handler logger (`event.locals.logger`). The helper itself stays logger-agnostic.
+- Filename `DDMMYYYYHHmmss_{quizTitle}_user_report.xlsx`, sheet `"Quiz Report"`. The `DDMMYYYYHHmmss` prefix comes from the shared `formatTimestamp`; the endpoint assembles the rest. `quizTitle` comes from a one-off `db.learningUnit.findUnique` (when `quizId` is set), run in the endpoint **before** calling `generateReport` and passed in as `filename` — the `fetchBatch` contract covers row batches only, not this header lookup.
+- Update the download link in `src/routes/admin/(protected)/reports/+page.svelte` to `/admin/api/download/quiz?quizId=...`.
+
+## Error handling
+
+- **Before streaming:** unauthenticated request → 401; a supplied `quizId` that resolves to no quiz → 404 (the endpoint does not conflate "not found" with "empty result"); the `quizTitle` lookup runs before `generateReport`, so a lookup failure is a clean 500 and a missing quiz a clean 404 — both before any bytes are sent.
+- **Frontend on error:** the download stays a native anchor navigation (`data-sveltekit-reload`), deliberately not a `fetch`, so the browser streams the response straight to disk with near-zero client memory — the point of the feature. The trade-off is that a non-200 (401/404/500) is a full navigation showing the raw body rather than an in-page error. This is acceptable because the quiz dropdown only offers valid ids, so the 404 path is near-unreachable from the UI (it covers deleted/stale ids and direct URL access). Graceful in-page error UX would require buffering the file in browser memory (blob) or the File System Access API, and is intentionally out of scope.
+- **Mid-stream (after headers sent):** the status and headers are already committed, so an error during the fetch/write loop cannot become a clean 500. The un-awaited write loop's `.catch` always destroys the `PassThrough` (the browser sees a failed/incomplete download and the admin retries) and, if the caller supplied `onError`, invokes it — the quiz endpoint supplies one that logs server-side through its handler logger. A buffer-then-send fallback was rejected (see [ADR-0001](../../decisions/0001-stream-report-exports-with-exceljs.md)) because it reintroduces the memory cost being removed.
+
+## Security considerations
+
+- **CSV / formula injection (OWASP A03).** `user.name` is end-user-controlled; `sanitizeSpreadsheetCell` neutralizes formula-triggering leading characters on all string cells.
+- **Information disclosure (STRIDE).** `Cache-Control: no-store` on the PII response; only required fields selected.
+- **Access control (OWASP A01; STRIDE: EoP / Info Disclosure).** Unchanged — `/admin/**` is gated by `src/routes/admin/hooks.server.ts`; the per-handler 401 stays as defense-in-depth.
+- **Denial of Service (STRIDE).** Addressed directly by this spec — cursor-batched reads + streamed output bound memory.
+- **CSRF / Tampering.** N/A — read-only `GET`, no state mutation.
+
+## Testing
+
+AAA, inline setup, no shared test helpers:
+
+- `sanitizeSpreadsheetCell`: prefixes leading `= + - @`, tab, CR; leaves safe values unchanged.
+- `formatTimestamp`: returns 14 zero-padded digits (`DDMMYYYYHHmmss`) for a known `Date`.
+- `generateReport`: drives `fetchBatch` until `nextCursor` is undefined; produces a readable stream; on a `fetchBatch` error, aborts the stream and calls `onError` when provided, and aborts without throwing (no unhandled rejection) when `onError` is omitted.
+- Quiz endpoint: 401 when unauthenticated; 404 when a supplied `quizId` resolves to no quiz; correct columns/row mapping; cursor advances across multiple batches; honors `quizId` filter.
+- Boundary conditions: empty result set yields a valid header-only workbook; with no `quizId`, the existing `where` runs without the optional filter.

--- a/docs/superpowers/specs/README.md
+++ b/docs/superpowers/specs/README.md
@@ -1,0 +1,51 @@
+# Specs
+
+Design specs for features and refactors, produced by the brainstorming flow
+before any implementation. Start every spec from [`TEMPLATE.md`](./TEMPLATE.md).
+
+- **Specs:** `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
+- **Plans:** `docs/superpowers/plans/` (written after the spec is approved)
+- **Decisions:** `../../decisions/` — ADRs in [MADR 4.0](https://adr.github.io/madr/) format
+
+## What a spec is for
+
+A spec answers **WHAT** we're building and **WHY**, and defines the **contracts
+and boundaries** other work depends on. It is the contract between intent and
+implementation. It does **not** contain implementation — no function bodies, no
+loop internals. That belongs in the plan.
+
+## What it must cover (from the brainstorming skill)
+
+- **Architecture, components, data flow, error handling, testing** — the skill's
+  required coverage for any design.
+- **Contracts / boundaries — the unit triple.** For each new or changed unit,
+  state _what it does, how you use it, and what it depends on_, plus what it
+  **guarantees** and what it **requires** of callers. Apply the information-hiding
+  test: can someone understand the unit without reading its internals, and can
+  you change the internals without breaking consumers? If not, the boundary needs
+  work. Interface **signatures** belong here; bodies do not.
+- **Chosen solution only.** A spec records the decision you landed on. The
+  alternatives you considered and the full rationale go in an **ADR** under
+  `docs/decisions/` (MADR 4.0); the spec links to it. See the decisions
+  [README](../../decisions/README.md).
+- **YAGNI.** No unrequested features or speculative generality; state what's
+  deliberately excluded in the overview's scope-boundary line.
+
+## Diagrams
+
+Use **Mermaid** fenced code blocks for all diagrams (flow, sequence, ER) so they
+render in the repo and in review:
+
+````markdown
+```mermaid
+flowchart LR
+  A[Request] --> B[Handler] --> C[(DB)]
+```
+````
+
+## Review bar
+
+Before handing a spec to planning it should pass the skill reviewer's bar:
+**Completeness** (no TBD/placeholders), **Consistency** (no contradictions),
+**Clarity** (no requirement readable two ways), **Scope** (focused enough for a
+single plan), **YAGNI** (nothing unrequested).

--- a/docs/superpowers/specs/TEMPLATE.md
+++ b/docs/superpowers/specs/TEMPLATE.md
@@ -1,0 +1,147 @@
+# <Feature> — Design
+
+<!--
+SPEC TEMPLATE — read before filling in. See README.md for the full conventions.
+
+A spec answers WHAT we're building and WHY, and defines the CONTRACTS and
+BOUNDARIES other work depends on. It does NOT contain implementation: no function
+bodies, no loop internals. That is the plan's job.
+
+Decisions: record only the CHOSEN solution here. The alternatives considered and
+the full rationale go in an ADR under docs/decisions/ (MADR 4.0); link it.
+
+Altitude test for anything you add:
+  - Contract / interface / chosen outcome a reviewer or sibling spec must consume -> here
+  - Internal mechanics a competent engineer could write 3 valid ways -> the plan
+  - "We considered X but chose Y because…" -> an ADR in docs/decisions/, linked from here
+
+Diagrams: use Mermaid fenced blocks. Scale each section to its complexity and
+DELETE optional sections that don't apply (an empty section reads as unanswered).
+Delete these comments in the real spec.
+-->
+
+**Status:** Draft <!-- Draft | Approved -->
+**Issue:** <link to tracking issue, or "none">
+**Depends on / Related:** <link sibling specs/ADRs, or delete>
+
+## Overview
+
+<!--
+Problem first, then the solution, then why this approach — one tight description.
+A reader should finish knowing what's broken/missing, what we'll build, and why
+it's worth doing. State the scope boundary explicitly (what this does NOT cover,
+especially if a sibling spec covers it).
+-->
+
+## Goals
+
+<!-- Bullets. The success criteria the design must meet. Lead with the quality
+attribute being optimized (e.g. bounded memory, p99 latency, auditability) when
+there is one. Scope exclusions belong in the Overview's scope-boundary line, not
+here. -->
+
+- **Goal:** …
+
+## Requirements
+
+<!-- OPTIONAL — feature specs. Externally-defined must-haves (e.g. from the
+issue). A column/format table is ideal when output shape is fixed. Delete for
+pure refactors. -->
+
+## Data model
+
+<!-- OPTIONAL — when the work touches the schema or non-obvious relations. Name
+only the models/fields/relations involved and how they map to the feature; don't
+restate the whole schema. An ER diagram (Mermaid `erDiagram`) helps when
+relations are the point. Delete if not applicable. -->
+
+## Architecture
+
+<!--
+Describe the CHOSEN design and how it works at the contract level — components and
+how data flows between them. Use a Mermaid diagram when the flow is non-trivial.
+Do NOT relitigate alternatives here; for any significant decision, link the ADR
+that records the options and rationale:
+
+> Decision: <chosen approach>. See [ADR-0001](../../decisions/0001-<slug>.md).
+
+```mermaid
+flowchart LR
+  A[Request] --> B[Handler] --> C[(DB)]
+
+````
+-->
+
+## Contracts & boundaries
+
+<!--
+For each NEW or CHANGED unit (module, helper, endpoint), state the boundary so a
+consumer never needs to read the internals:
+
+### `unit name`
+- **Does:** <one line — its single purpose>
+- **Use:** <how a caller invokes it; include the type SIGNATURE, no body>
+- **Depends on:** <what it needs>
+- **Guarantees:** <postconditions — what callers can rely on>
+- **Requires:** <preconditions — what the caller must provide / hold>
+
+Information-hiding test: can the internals change without breaking consumers? If
+not, the boundary is wrong.
+
+Write these as declaration-level TypeScript — signatures only, never bodies. Use
+`interface` for object shapes (this repo lints `consistent-type-definitions:
+interface` via the typescript-eslint stylistic preset); reserve `type` for
+unions, function types, and mapped/utility types. Type imports are inline
+(`import { type Foo }`).
+
+```ts
+interface Thing<T> { … }
+doThing(input): Output;
+````
+
+-->
+
+## Components / changes
+
+<!--
+Concrete, file-level list of what changes — one numbered entry per file/unit:
+path, new|moved|modified, and WHAT it does at the contract level (columns,
+inputs, outputs, filters). No code bodies. Call out preserved behavior explicitly
+when rewriting existing code.
+-->
+
+### 1. `path/to/file` (new | moved | modified)
+
+…
+
+## Error handling
+
+<!-- How failures are handled at each boundary: what's validated, what's caught,
+what status/log/abort results. Call out failures that can't become a clean error
+(e.g. mid-stream after headers are sent). -->
+
+## Security considerations
+
+<!--
+Threats via STRIDE / OWASP Top 10, scaled to the feature. Per relevant threat:
+name it (with tag), state the exposure, state the mitigation (or why N/A). Be
+explicit about what's handled centrally (e.g. an auth hook) vs. in this change.
+Say "N/A — <reason>" rather than omitting a category.
+-->
+
+- **Access control (OWASP A01; STRIDE: EoP / Info Disclosure).** …
+- **Injection (OWASP A03).** …
+- **Information disclosure (STRIDE).** …
+- **CSRF / Tampering.** …
+- **Denial of Service (STRIDE).** …
+
+## Testing
+
+<!--
+Test cases that prove the spec is satisfied, at the behavior level. Follow the
+project's test conventions (AAA, inline setup, no shared helpers). Group by unit.
+Include boundary conditions as cases (empty result set, missing optional field,
+single vs multiple batches); error-path conditions belong in Error handling.
+State what's covered elsewhere (e.g. a dependency spec) to avoid implying
+duplication.
+-->


### PR DESCRIPTION
## 🚀 Summary

This PR adds the design spec for memory-bounded, end-to-end streaming report exports (Spec A).

## ✏️ Changes

- Add the streaming report exports design spec
- Add the `docs/superpowers/specs/` README and template

Stacked on #575. Part of #571.
