### PR TITLE
fix(onboarding): source topic list from DB to stop selections being silently dropped

### DIFF
--- a/src/lib/components/OnboardingView/OnboardingView.svelte
+++ b/src/lib/components/OnboardingView/OnboardingView.svelte
@@ -8,6 +8,17 @@
   import { Modal } from '$lib/components/Modal/index.js';
   import { IsWithinViewport } from '$lib/helpers/index.js';
 
+  export interface Topic {
+    id: string;
+    title: string;
+    description: string;
+    /**
+     * The associated tag code (e.g. `AI`, `BOB`), used to select the topic
+     * icon. Null when the collection has no tag.
+     */
+    code: string | null;
+  }
+
   export interface Props {
     /**
      * Indicates whether the view is open.
@@ -17,9 +28,37 @@
      * A callback invoked when the view is closed.
      */
     onclose: () => void;
+    /**
+     * The selectable topic collections, sourced from the database.
+     */
+    topics: Topic[];
   }
 
-  const { isopen, onclose }: Props = $props();
+  const { isopen, onclose, topics }: Props = $props();
+
+  /**
+   * Tag codes that have a topic icon. Keep in sync with the `enhanced:img`
+   * mapping in the topic-selection markup below; a topic whose code is not
+   * here has no icon and is not shown.
+   */
+  const TOPIC_ICON_CODES = new Set([
+    'AI',
+    'CAREER',
+    'EDU_VOICES',
+    'EMP_ENGAGEMENT',
+    'NEWS',
+    'INFRA',
+    'INNOV',
+    'BOB',
+    'PROD',
+    'STU_DEV',
+    'STU_WELL',
+    'WELLBEING',
+  ]);
+
+  const displayedTopics = $derived(
+    topics.filter((topic) => topic.code !== null && TOPIC_ICON_CODES.has(topic.code)),
+  );
 
   let target = $state<HTMLElement | null>(null);
   let isStartPage = $state(true);
@@ -64,7 +103,7 @@
 
   const handleConfirm = async () => {
     const payload = {
-      topics: selectedTopics,
+      collectionIds: selectedTopics,
       frequency: selectedFrequency,
       csrfToken: page.data.csrfToken,
     };
@@ -127,67 +166,12 @@
     await handleClose();
   };
 
-  const handleTopicChange = (title: string, checked: boolean) => {
+  const handleTopicChange = (id: string, checked: boolean) => {
     if (checked) {
-      selectedTopics = [...selectedTopics, title];
+      selectedTopics = [...selectedTopics, id];
     } else {
-      selectedTopics = selectedTopics.filter((topic) => topic !== title);
+      selectedTopics = selectedTopics.filter((topic) => topic !== id);
     }
-  };
-
-  const collectionsList = {
-    'artificial-intelligence': {
-      title: 'Artificial Intelligence',
-      description: 'AI news, use cases and tools to master the changing landscape.',
-    },
-    'career-growth': {
-      title: 'Career Growth',
-      description: 'Tips to help you set career goals and transform potential into performance.',
-    },
-    'educator-voices': {
-      title: 'Educator Voices',
-      description: 'Inspiring stories from fellow educators.',
-    },
-    'employee-engagement': {
-      title: 'Employee Engagement',
-      description:
-        'Analyze EES results and get practical tips to maintain workplace staff engagement.',
-    },
-    'in-the-news': {
-      title: 'In the News',
-      description: 'Education news and survey highlights for ground insights.',
-    },
-    infrastructure: {
-      title: 'Infrastructure',
-      description: 'Learn about device setups, connectivity, and digital tools for efficient work.',
-    },
-    innovation: {
-      title: 'Innovation',
-      description: 'Strategies to empower new ideas, innovation, and creative thinking.',
-    },
-    'learn-with-bob': {
-      title: 'Learn with Bob',
-      description: 'SPACES framework for purposeful work and a sustainable pace.',
-    },
-    productivity: {
-      title: 'Productivity',
-      description:
-        'Master time management and workflows to minimize distractions and reach goals faster.',
-    },
-    'student-development': {
-      title: 'Student Development',
-      description:
-        "Learn ways to develop students' cognitive, affective, physical and aesthetic abilities.",
-    },
-    'student-wellbeing': {
-      title: 'Student Wellbeing',
-      description: 'Learn ways to support students emotional and physical health.',
-    },
-    wellbeing: {
-      title: 'Wellbeing',
-      description:
-        'Identify workplace stress, monitor peer distress, conduct check-ins, and provide support resources.',
-    },
   };
 </script>
 
@@ -277,7 +261,7 @@
 
           <div class="overflow-y-auto pt-6">
             <div class="flex w-full flex-col gap-y-2" role="group" aria-labelledby="topic">
-              {#each Object.entries(collectionsList) as [key, { title, description }] (key)}
+              {#each displayedTopics as { id, title, description, code } (id)}
                 <label
                   class={[
                     'group flex cursor-pointer items-center rounded-3xl border border-slate-200 bg-white',
@@ -291,79 +275,79 @@
                     <input
                       type="checkbox"
                       name="topics"
-                      value={title}
+                      value={id}
                       class="sr-only"
-                      onchange={(e) => handleTopicChange(title, e.currentTarget.checked)}
+                      onchange={(e) => handleTopicChange(id, e.currentTarget.checked)}
                     />
 
                     <div class="flex h-24 w-20 shrink-0 items-center justify-center">
-                      {#if key === 'artificial-intelligence'}
+                      {#if code === 'AI'}
                         <enhanced:img
                           src="$lib/assets/collections/artificial-intelligence.png"
                           alt={title}
                           class="max-h-full max-w-full object-contain"
                         />
-                      {:else if key === 'career-growth'}
+                      {:else if code === 'CAREER'}
                         <enhanced:img
                           src="$lib/assets/collections/career-growth.png"
                           alt={title}
                           class="max-h-full max-w-full object-contain"
                         />
-                      {:else if key === 'educator-voices'}
+                      {:else if code === 'EDU_VOICES'}
                         <enhanced:img
                           src="$lib/assets/collections/educator-voices.png"
                           alt={title}
                           class="max-h-full max-w-full object-contain"
                         />
-                      {:else if key === 'employee-engagement'}
+                      {:else if code === 'EMP_ENGAGEMENT'}
                         <enhanced:img
                           src="$lib/assets/collections/employee-engagement.png"
                           alt={title}
                           class="max-h-full max-w-full object-contain"
                         />
-                      {:else if key === 'in-the-news'}
+                      {:else if code === 'NEWS'}
                         <enhanced:img
                           src="$lib/assets/collections/in-the-news.png"
                           alt={title}
                           class="max-h-full max-w-full object-contain"
                         />
-                      {:else if key === 'infrastructure'}
+                      {:else if code === 'INFRA'}
                         <enhanced:img
                           src="$lib/assets/collections/infrastructure.png"
                           alt={title}
                           class="max-h-full max-w-full object-contain"
                         />
-                      {:else if key === 'innovation'}
+                      {:else if code === 'INNOV'}
                         <enhanced:img
                           src="$lib/assets/collections/innovation.png"
                           alt={title}
                           class="max-h-full max-w-full object-contain"
                         />
-                      {:else if key === 'learn-with-bob'}
+                      {:else if code === 'BOB'}
                         <enhanced:img
                           src="$lib/assets/collections/learn-with-bob.png"
                           alt={title}
                           class="max-h-full max-w-full object-contain"
                         />
-                      {:else if key === 'productivity'}
+                      {:else if code === 'PROD'}
                         <enhanced:img
                           src="$lib/assets/collections/productivity.png"
                           alt={title}
                           class="max-h-full max-w-full object-contain"
                         />
-                      {:else if key === 'student-development'}
+                      {:else if code === 'STU_DEV'}
                         <enhanced:img
                           src="$lib/assets/collections/student-development.png"
                           alt={title}
                           class="max-h-full max-w-full object-contain"
                         />
-                      {:else if key === 'student-wellbeing'}
+                      {:else if code === 'STU_WELL'}
                         <enhanced:img
                           src="$lib/assets/collections/student-wellbeing.png"
                           alt={title}
                           class="max-h-full max-w-full object-contain"
                         />
-                      {:else if key === 'wellbeing'}
+                      {:else if code === 'WELLBEING'}
                         <enhanced:img
                           src="$lib/assets/collections/wellbeing.png"
                           alt={title}

--- a/src/routes/(main)/(protected)/+layout.server.ts
+++ b/src/routes/(main)/(protected)/+layout.server.ts
@@ -55,6 +55,9 @@ export const load: LayoutServerLoad = async (event) => {
     where: {
       isTopic: true,
     },
+    orderBy: {
+      title: 'asc',
+    },
   } satisfies CollectionFindManyArgs;
 
   let topics: CollectionGetPayload<typeof topicArgs>[];

--- a/src/routes/(main)/(protected)/+layout.server.ts
+++ b/src/routes/(main)/(protected)/+layout.server.ts
@@ -1,6 +1,12 @@
 import { error, redirect } from '@sveltejs/kit';
 
-import { db, type UserFindUniqueArgs, type UserGetPayload } from '$lib/server/db';
+import {
+  type CollectionFindManyArgs,
+  type CollectionGetPayload,
+  db,
+  type UserFindUniqueArgs,
+  type UserGetPayload,
+} from '$lib/server/db';
 
 import type { LayoutServerLoad } from './$types';
 
@@ -35,9 +41,42 @@ export const load: LayoutServerLoad = async (event) => {
 
   const onboarded = userData?.userProfile;
 
+  const topicArgs = {
+    select: {
+      id: true,
+      title: true,
+      description: true,
+      tag: {
+        select: {
+          code: true,
+        },
+      },
+    },
+    where: {
+      isTopic: true,
+    },
+  } satisfies CollectionFindManyArgs;
+
+  let topics: CollectionGetPayload<typeof topicArgs>[];
+  try {
+    topics = await db.collection.findMany(topicArgs);
+  } catch (err) {
+    logger.error({ err }, 'Failed to retrieve topic collections');
+    throw error(500);
+  }
+
   return {
     username: user.name,
     csrfToken: event.locals.session.csrfToken(),
     onboarded,
+    // Keyed distinctly from the home page's own `topics` (different shape):
+    // page data overrides layout data on key collision, so a shared `topics`
+    // key would let the home page shadow these and break the onboarding picker.
+    onboardingTopics: topics.map((topic) => ({
+      id: topic.id,
+      title: topic.title,
+      description: topic.description,
+      code: topic.tag?.code ?? null,
+    })),
   };
 };

--- a/src/routes/(main)/(protected)/+layout.svelte
+++ b/src/routes/(main)/(protected)/+layout.svelte
@@ -329,4 +329,8 @@
 
 <ChatView isopen={isChatViewOpen} onclose={handleChatViewClose} />
 
-<OnboardingView isopen={isOnboardingViewOpen} onclose={handleOnboardingViewClose} />
+<OnboardingView
+  isopen={isOnboardingViewOpen}
+  onclose={handleOnboardingViewClose}
+  topics={page.data.onboardingTopics ?? []}
+/>

--- a/src/routes/(main)/api/onboarding/+server.ts
+++ b/src/routes/(main)/api/onboarding/+server.ts
@@ -1,6 +1,11 @@
 import { json } from '@sveltejs/kit';
 
-import { db, type UserProfileCreateArgs } from '$lib/server/db';
+import {
+  type CollectionFindManyArgs,
+  type CollectionGetPayload,
+  db,
+  type UserProfileCreateArgs,
+} from '$lib/server/db';
 
 import type { RequestHandler } from './$types';
 
@@ -25,9 +30,10 @@ export const POST: RequestHandler = async (event) => {
     if (
       !params ||
       typeof params !== 'object' ||
-      !('topics' in params) ||
-      !Array.isArray(params['topics']) ||
-      params['topics'].length < 3 ||
+      !('collectionIds' in params) ||
+      !Array.isArray(params['collectionIds']) ||
+      params['collectionIds'].length < 3 ||
+      !params['collectionIds'].every((id: unknown) => typeof id === 'string') ||
       !('frequency' in params) ||
       typeof params['frequency'] !== 'string' ||
       !('csrfToken' in params) ||
@@ -40,24 +46,34 @@ export const POST: RequestHandler = async (event) => {
     return json(null, { status: 400 });
   }
 
-  const { topics, frequency } = params;
+  const { collectionIds, frequency } = params;
+
+  const uniqueCollectionIds = [...new Set<string>(collectionIds)];
 
   try {
-    const collections = await db.collection.findMany({
+    const collectionArgs = {
       select: {
         id: true,
       },
       where: {
-        title: {
-          in: topics,
+        id: {
+          in: uniqueCollectionIds,
         },
         isTopic: true,
       },
-    });
+    } satisfies CollectionFindManyArgs;
 
-    if (collections.length === 0) {
-      logger.warn({ topics }, 'No valid collections found');
-      return json(null, { status: 400 });
+    const collections: CollectionGetPayload<typeof collectionArgs>[] =
+      await db.collection.findMany(collectionArgs);
+
+    if (collections.length !== uniqueCollectionIds.length) {
+      const resolvedIds = new Set(collections.map((collection) => collection.id));
+      const unresolvedIds = uniqueCollectionIds.filter((id) => !resolvedIds.has(id));
+      logger.warn(
+        { userId: user.id, submittedIds: uniqueCollectionIds, unresolvedIds },
+        'One or more collectionIds did not resolve to a topic collection',
+      );
+      return json(null, { status: 422 });
     }
 
     const userProfileArgs = {

--- a/src/routes/(main)/api/onboarding/server.test.ts
+++ b/src/routes/(main)/api/onboarding/server.test.ts
@@ -1,0 +1,235 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { POST } from './+server.js';
+
+const { mockFindMany, mockCreate } = vi.hoisted(() => ({
+  mockFindMany: vi.fn(),
+  mockCreate: vi.fn(),
+}));
+
+vi.mock('$lib/server/db', () => ({
+  db: {
+    collection: { findMany: mockFindMany },
+    userProfile: { create: mockCreate },
+  },
+}));
+
+const silentLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  child: vi.fn(),
+};
+silentLogger.child.mockReturnValue(silentLogger);
+
+interface BuildEventOptions {
+  user?: { id: string } | null;
+  contentType?: string | null;
+  body?: unknown;
+  rawBody?: string;
+}
+
+const buildEvent = ({
+  user = { id: 'user-1' },
+  contentType = 'application/json',
+  body,
+  rawBody,
+}: BuildEventOptions) =>
+  ({
+    locals: { logger: silentLogger, session: { user } },
+    request: {
+      headers: {
+        get: (name: string) => (name.toLowerCase() === 'content-type' ? contentType : null),
+      },
+      json: async () => {
+        if (rawBody !== undefined) {
+          return JSON.parse(rawBody);
+        }
+        return body;
+      },
+    },
+  }) as unknown as Parameters<typeof POST>[0];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  silentLogger.child.mockReturnValue(silentLogger);
+});
+
+describe('POST /api/onboarding', () => {
+  test('returns 401 when unauthenticated', async () => {
+    const event = buildEvent({ user: null });
+
+    const response = await POST(event);
+
+    expect(response.status).toBe(401);
+    expect(mockFindMany).not.toHaveBeenCalled();
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  test('returns 415 when content-type is not application/json', async () => {
+    const event = buildEvent({ contentType: 'text/plain' });
+
+    const response = await POST(event);
+
+    expect(response.status).toBe(415);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  test('returns 400 when the request JSON fails to parse', async () => {
+    const event = buildEvent({ rawBody: '{not json' });
+
+    const response = await POST(event);
+
+    expect(response.status).toBe(400);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  test('returns 422 when fewer than three collectionIds are submitted', async () => {
+    const event = buildEvent({
+      body: {
+        collectionIds: ['c1', 'c2'],
+        frequency: 'QUICK',
+        csrfToken: 'token',
+      },
+    });
+
+    const response = await POST(event);
+
+    expect(response.status).toBe(422);
+    expect(mockFindMany).not.toHaveBeenCalled();
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  test('returns 422 when a collectionId entry is not a string', async () => {
+    const event = buildEvent({
+      body: {
+        collectionIds: ['c1', 'c2', 42],
+        frequency: 'QUICK',
+        csrfToken: 'token',
+      },
+    });
+
+    const response = await POST(event);
+
+    expect(response.status).toBe(422);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  test('returns 422 when required fields are missing or wrong-typed', async () => {
+    const event = buildEvent({
+      body: {
+        collectionIds: ['c1', 'c2', 'c3'],
+        frequency: 'QUICK',
+        // csrfToken missing
+      },
+    });
+
+    const response = await POST(event);
+
+    expect(response.status).toBe(422);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  test('returns 200 and writes one interest per submitted id when all ids resolve', async () => {
+    mockFindMany.mockResolvedValue([{ id: 'c1' }, { id: 'c2' }, { id: 'c3' }]);
+    mockCreate.mockResolvedValue({});
+    const event = buildEvent({
+      body: {
+        collectionIds: ['c1', 'c2', 'c3'],
+        frequency: 'QUICK',
+        csrfToken: 'token',
+      },
+    });
+
+    const response = await POST(event);
+
+    expect(response.status).toBe(200);
+    expect(mockFindMany).toHaveBeenCalledTimes(1);
+    expect(mockFindMany.mock.calls[0][0]).toMatchObject({
+      where: { id: { in: ['c1', 'c2', 'c3'] }, isTopic: true },
+    });
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    const createArgs = mockCreate.mock.calls[0][0];
+    expect(createArgs.data.userId).toBe('user-1');
+    expect(createArgs.data.learningFrequency).toBe('QUICK');
+    expect(createArgs.data.interests.create).toEqual([
+      { collectionId: 'c1' },
+      { collectionId: 'c2' },
+      { collectionId: 'c3' },
+    ]);
+  });
+
+  test('returns 422 and writes nothing when a single id does not resolve', async () => {
+    mockFindMany.mockResolvedValue([{ id: 'c1' }, { id: 'c2' }]);
+    const event = buildEvent({
+      body: {
+        collectionIds: ['c1', 'c2', 'c3'],
+        frequency: 'QUICK',
+        csrfToken: 'token',
+      },
+    });
+
+    const response = await POST(event);
+
+    expect(response.status).toBe(422);
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(silentLogger.warn).toHaveBeenCalled();
+  });
+
+  test('does not create duplicate interests for repeated collectionIds', async () => {
+    mockFindMany.mockResolvedValue([{ id: 'c1' }, { id: 'c2' }, { id: 'c3' }]);
+    mockCreate.mockResolvedValue({});
+    const event = buildEvent({
+      body: {
+        collectionIds: ['c1', 'c1', 'c2', 'c3'],
+        frequency: 'QUICK',
+        csrfToken: 'token',
+      },
+    });
+
+    const response = await POST(event);
+
+    expect(response.status).toBe(200);
+    const createArgs = mockCreate.mock.calls[0][0];
+    expect(createArgs.data.interests.create).toEqual([
+      { collectionId: 'c1' },
+      { collectionId: 'c2' },
+      { collectionId: 'c3' },
+    ]);
+  });
+
+  test('returns 500 when the collection lookup fails', async () => {
+    mockFindMany.mockRejectedValue(new Error('db down'));
+    const event = buildEvent({
+      body: {
+        collectionIds: ['c1', 'c2', 'c3'],
+        frequency: 'QUICK',
+        csrfToken: 'token',
+      },
+    });
+
+    const response = await POST(event);
+
+    expect(response.status).toBe(500);
+    expect(silentLogger.error).toHaveBeenCalled();
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  test('returns 500 when the profile write fails', async () => {
+    mockFindMany.mockResolvedValue([{ id: 'c1' }, { id: 'c2' }, { id: 'c3' }]);
+    mockCreate.mockRejectedValue(new Error('write failed'));
+    const event = buildEvent({
+      body: {
+        collectionIds: ['c1', 'c2', 'c3'],
+        frequency: 'QUICK',
+        csrfToken: 'token',
+      },
+    });
+
+    const response = await POST(event);
+
+    expect(response.status).toBe(500);
+    expect(silentLogger.error).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 🚀 Summary

Closes #598.

The onboarding topic picker rendered a **hardcoded** list and submitted display **titles**, which the POST handler matched case-sensitively against `Collection.title`. The UI list and DB drifted (`Artificial Intelligence` vs `AI`, `Educator Voices` vs `Educators Voices`, etc.), so selections silently failed to match — some learners couldn't complete onboarding (400, no profile created), others had picks dropped with no error (200, partial save).

This sources the selectable topics from the database and submits collection **ids**, so the picker and the validator can never drift again.

## ✏️ Changes

- **`(protected)/+layout.server.ts`** — query topic collections (`isTopic = true`, selecting `id`, `title`, `description`, `tag.code`) and expose them as **`onboardingTopics`**. Keyed distinctly from the home page's own `topics` (different shape) — page data overrides layout data on key collision, which would otherwise leave the picker empty.
- **`(protected)/+layout.svelte`** — pass `onboardingTopics` down to `OnboardingView`.
- **`OnboardingView.svelte`** — remove the hardcoded `collectionsList`; accept a typed `topics` prop; render from it; submit collection ids. Icons are keyed off the stable **tag code** (e.g. `AI`, `BOB`) — the same identifier `Collection.svelte` uses — not titles/slugs, so they can't drift. Topics without a known icon are filtered out and not shown.
- **`api/onboarding/+server.ts`** — request body changes from `topics` (titles) to `collectionIds` (UUIDs). Ids are resolved strictly: if the resolved `isTopic = true` count ≠ submitted (deduped) count, log a warning and return **422** instead of saving a partial profile. Duplicate ids are deduped so they can't create duplicate `UserInterest` rows. `csrfToken` handling and `LearningFrequency` mapping unchanged.
- **`api/onboarding/server.test.ts`** — new tests covering the full success/error contract (401, 415, 400, 422 for invalid body / fewer than 3 / unresolved id, dedup, 500 on DB failure, 200 with one interest per id).

No Prisma schema change or migration.

## ✅ Verification

- `pnpm test run` — 350/350 pass (11 new onboarding handler tests).
- `pnpm check` — 0 errors, 0 warnings.
- Manually verified the picker renders the seeded topics with icons on the home route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)