### PR TITLE
release: v1.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.15.1 (2026-06-25)
+
+### Bug Fixes 🐛
+
+- fix(onboarding): source topic list from DB to stop selections being silently dropped ([#599](https://github.com/String-sg/onward/pull/599)) ([0eb6d4e](https://github.com/String-sg/onward/commit/0eb6d4e))
+
 ## 1.15.0 (2026-06-11)
 
 ### Features ✨

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onward",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.33.4",


### PR DESCRIPTION
## 1.15.1 (2026-06-25)

### Bug Fixes 🐛

- fix(onboarding): source topic list from DB to stop selections being silently dropped ([#599](https://github.com/String-sg/onward/pull/599)) ([0eb6d4e](https://github.com/String-sg/onward/commit/0eb6d4e))
