### PR TITLE
release: v1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.16.0 (2026-07-01)
+
+### Features ✨
+
+- feat(auth): support multiple Google hosted domains ([#605](https://github.com/String-sg/onward/pull/605)) ([d30cc2e](https://github.com/String-sg/onward/commit/d30cc2e))
+
+### Chores 🧹
+
+- chore: update vulnerable dependencies ([#607](https://github.com/String-sg/onward/pull/607)) ([3d1f10d](https://github.com/String-sg/onward/commit/3d1f10d))
+
 ## 1.15.1 (2026-06-25)
 
 ### Bug Fixes 🐛

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onward",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.33.4",


### PR DESCRIPTION
## 🚀 Summary

Release **v1.16.0**. Bumps `package.json` to `1.16.0` and updates `CHANGELOG.md`. Merging this PR tags `v1.16.0` and builds/pushes the release image (see `.github/workflows/release.yaml`).

## ✏️ Changes

### Features ✨

- feat(auth): support multiple Google hosted domains ([#605](https://github.com/String-sg/onward/pull/605)) ([d30cc2e](https://github.com/String-sg/onward/commit/d30cc2e))

### Chores 🧹

- chore: update vulnerable dependencies ([#607](https://github.com/String-sg/onward/pull/607)) ([3d1f10d](https://github.com/String-sg/onward/commit/3d1f10d)) — resolves all 20 Dependabot advisories (4 high / 12 moderate / 4 low) and prunes 10 stale pnpm overrides down to 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
